### PR TITLE
release: HyperEars v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 本项目遵循 [Semantic Versioning](https://semver.org/)。公开版本变化记录在此文件中。
 
+## [0.11.0] - 2026-08-01
+
+### Added
+
+- 增加 Edifier W860NB PRO 实机协议适配，支持整机电量、深度降噪、环境声、关闭和
+  防风噪控制。
+- 增加 W860NB PRO 专属 MiLink 四模式卡片，以及 Edifier BES 协议实验室只读探测。
+
+### Architecture
+
+- Edifier 采用“标准耳机 → 厂商家族 → 具体型号”适配器层级；未实机验证的家族
+  型号只提供保守回退，不开放推测性控制能力。
+- W860NB PRO 的模式切换遵循设备语音播报窗口限流，并按设备地址隔离控制状态。
+
 ## [0.10.4] - 2026-08-01
 
 ### Fixed
@@ -56,6 +70,7 @@
 - Release 构建改用独立环境变量签名，不再使用 debug 证书。
 - 增加 CI、标签发布、APK 签名验证和 SHA-256 产物。
 
+[0.11.0]: https://github.com/silverpoetry/HyperEars/releases/tag/v0.11.0
 [0.10.4]: https://github.com/silverpoetry/HyperEars/releases/tag/v0.10.4
 [0.10.3]: https://github.com/silverpoetry/HyperEars/releases/tag/v0.10.3
 [0.10.2]: https://github.com/silverpoetry/HyperEars/releases/tag/v0.10.2

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ HyperEars **不会**替换 Android 的 A2DP/HFP 音频链路，不会把音频�
 | Bose QuietComfort Headphones (`prince/0x4075`) | 实机验证 | 整机 | 安静/感知/含风噪预设 | 是 |
 | 其他 Bose BMAP 耳机 | 保守回退 | 视 BMAP 响应 | 不声明未验证模式 | 是 |
 | OPPO Enco 家族 | 参考协议盲适配 | 左/右/盒 | 降噪/关闭/通透 | 是 |
+| Edifier W860NB PRO | 实机验证 | 整机 | 深度/舒适降噪、风噪、环境声、关闭 | 是 |
 | 其他标准蓝牙耳机 | 通用回退 | 系统整机电量 | 无私有控制 | 是 |
 
 “公开实现画像”和“盲适配”不等于实机验证。完整型号、证据级别和已知限制见
@@ -146,6 +147,7 @@ CI 会验证单元测试、Lint 和 Release 编译；带 `v*` 标签的发布工
 - [OPPO Enco 协议](docs/oppo-enco-protocol.md)
 - [Bose BMAP 协议](docs/bose-bmap-protocol.md)
 - [StarRing Ultra 协议](docs/starring-ultra-protocol.md)
+- [Edifier (BES) 协议](docs/edifier-bes-protocol.md)
 
 ## 贡献
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Android 音频路由的前提下补充电量、降噪状态和设备流转所需
 
 > [!WARNING]
 > HyperEars 依赖 root、LSPosed 和 HyperOS 私有接口。安装前请确认能够恢复系统；ROM
-> 更新可能暂时破坏兼容性。本项目与 Xiaomi、vivo、iQOO、OPPO、Bose 及相关品牌无关。
+> 更新可能暂时破坏兼容性。本项目与 Xiaomi、vivo、iQOO、OPPO、Bose、Edifier
+> 及相关品牌无关。
 
 ## 能做什么
 
@@ -63,7 +64,7 @@ HyperEars **不会**替换 Android 的 A2DP/HFP 音频链路，不会把音频�
 2. 校验 SHA-256：
 
    ```powershell
-   Get-FileHash .\HyperEars-v0.10.4.apk -Algorithm SHA256
+    Get-FileHash .\HyperEars-v0.11.0.apk -Algorithm SHA256
    ```
 
 3. 安装 APK，在 LSPosed 中启用 HyperEars，并确认两个静态作用域均已选中。

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -39,6 +39,8 @@ HyperEars 的当前目标是 Android 15+ 的 Xiaomi HyperOS 和 LSPosed API 101�
 | OPPO Enco Air2 Pro | 规范化零售名称 | 参考协议盲适配 | 左/右/盒 | 反向 ANC/OFF 编码 |
 | OPPO Enco Free4/X3/Air5 | 规范化零售名称 | 预留具体 Profile | 左/右/盒 | 当前只暴露通用三态 |
 | 其他 OPPO/Enco | 家族名称 | 参考协议盲适配 | 左/右/盒 | ANC/OFF/通透 |
+| Edifier W860NB PRO | 规范化名称 + 头戴类 | 实机验证 | 单整机 | 深度/舒适降噪、风噪、环境声、关闭 |
+| 其他 Edifier 头戴 | 家族名称 + 头戴类 | 保守家族回退 | 单整机 | 按已发现模式开放 |
 | 标准 A2DP/HFP 耳机 | Android 设备类别、Profile 和保守名称 | 通用回退 | 系统整机电量复制为左右 | 无私有模式 |
 
 ## 4. vivo/iQOO 型号目录

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -40,7 +40,7 @@ HyperEars 的当前目标是 Android 15+ 的 Xiaomi HyperOS 和 LSPosed API 101�
 | OPPO Enco Free4/X3/Air5 | 规范化零售名称 | 预留具体 Profile | 左/右/盒 | 当前只暴露通用三态 |
 | 其他 OPPO/Enco | 家族名称 | 参考协议盲适配 | 左/右/盒 | ANC/OFF/通透 |
 | Edifier W860NB PRO | 规范化名称 + 头戴类 | 实机验证 | 单整机 | 深度/舒适降噪、风噪、环境声、关闭 |
-| 其他 Edifier 头戴 | 家族名称 + 头戴类 | 保守家族回退 | 单整机 | 按已发现模式开放 |
+| 其他 Edifier 头戴 | 家族名称 + 头戴类 | 推测性家族回退 | 协议响应可用时发布整机电量 | 不开放未验证控制 |
 | 标准 A2DP/HFP 耳机 | Android 设备类别、Profile 和保守名称 | 通用回退 | 系统整机电量复制为左右 | 无私有模式 |
 
 ## 4. vivo/iQOO 型号目录

--- a/docs/edifier-bes-protocol.md
+++ b/docs/edifier-bes-protocol.md
@@ -1,0 +1,117 @@
+# Edifier (BES/恒玄) Bluetooth Protocol Analysis
+
+> Verified on real hardware: Edifier W860NB PRO via LSPosed hook of Edifier Connect v8.4.39
+> Initial analysis from APK reverse engineering; frame format and ANC mapping confirmed by live capture.
+
+## SPP Connection
+
+- **Service UUID**: `EDF00000-EDFE-DFED-FEDF-EDFEDFEDFEDF`
+- **Fallback**: RFCOMM channel 1 via `BluetoothDevice.createRfcommSocket(1)`
+- **Connection order**: First try `createRfcommSocketToServiceRecord(uuid)`, on failure retry with channel 1
+
+## Frame Format (BLE v2, confirmed live)
+
+**App → Device (Send):**
+```
+[0xAA][APP_CODE][CMD_INDEX][LEN_H][LEN_L][PAYLOAD...][CRC]
+```
+Example: `AA EC D8 00 00 6E` (device function query)
+
+**Device → App (Response):**
+```
+[0xBB][APP_CODE][CMD_INDEX][LEN_H][LEN_L][PAYLOAD...][CRC]
+```
+Older firmware may use `0xCC`. Example: `BB EC D0 00 01 99 11` (battery response)
+
+| Field | Size | Description |
+|-------|------|-------------|
+| Header | 1 byte | Send=`0xAA`(170), Receive=`0xBB`(187), Old=`0xCC`(204) |
+| APP_CODE | 1 byte | `0xEC` (236) for app commands |
+| CMD_INDEX | 1 byte | Command identifier (see below) |
+| LENGTH | 2 bytes | Big-endian, payload length (not including header/CRC) |
+| PAYLOAD | N bytes | **Both send and receive payloads are XOR-encrypted with `0xA5`** |
+| CRC | 1 byte | Sum of all preceding bytes & 0xFF (computed over encrypted payload) |
+
+### Payload Encryption (XOR 0xA5, confirmed)
+
+Both directions carry XOR-`0xA5`-encrypted payloads. Key source:
+`ECCommand.EncryptionCode.Encryption10.value` = `Opcodes.IF_ACMPEQ` = 165 = `0xA5`.
+
+- Battery response: `0x99 ^ 0xA5 = 0x3C = 60%`
+- ANC response: `B5 A0 ^ A5 A5 = 10 05` → ancIndex=16, ancValue=5
+- ANC set (send): plaintext `10 04` is transmitted as `B5 A1`
+
+### CRC Verified
+
+- `AA EC D8 00 00` → 170+236+216 = 622 = 0x26E → `&0xFF` = `0x6E` ✓
+- `AA EC D0 00 00` → 170+236+208 = 614 = 0x266 → `&0xFF` = `0x66` ✓
+- `BB EC D0 00 01 99` → 187+236+208+0+1+153 = 785 = 0x311 → `&0xFF` = `0x11` ✓ (CRC over encrypted payload)
+
+## ANC Control (confirmed live)
+
+### Set ANC (cmd 0xC1 / 193)
+
+```
+[ancIndex][ancValue]
+```
+
+- **ancIndex** = `0x10` (16) — ANC16 slot on W860NB PRO
+- **ancValue** mapping (verified by live capture):
+
+| ancValue | Mode (中文) | Mode (EN) | NoiseMode |
+|----------|------------|-----------|-----------|
+| 1 | 深度降噪 | Deep NC | ANC |
+| 2 | 舒适降噪 | Comfort NC | ANC |
+| 3 | 防风噪 | Wind noise | WIND |
+| 4 | 环境声 | Ambient | TRANSPARENCY |
+| 5 | 降噪关 | NC Off | OFF |
+
+Live example: `AA EC C1 00 02 B5 A6 B4` = set wind noise mode
+(plaintext `10 03` → encrypted `B5 A6`; CRC: AA+EC+C1+00+02+B5+A6 = 0x2B4 → &0xFF = 0xB4 ✓)
+
+### Query ANC (cmd 0xCC / 204)
+
+```
+[empty payload]
+```
+Response payload is 2-3 bytes, XOR-encrypted. After decrypt:
+- byte[0] = ancIndex (`0x10`)
+- byte[1] = ancValue (1-5, see mapping above)
+
+Verified: `BB EC CC 00 02 B5 A0 CA` → `B5 A0` → decrypt `10 05` = NC off.
+
+### Query Battery (cmd 0xD0 / 208)
+
+```
+[empty payload]
+```
+Response example: `BB EC D0 00 01 99 11` — single-byte XOR-encrypted payload.
+`0x99 ^ 0xA5 = 0x3C = 60%`. Percent may include charging flag in high bit (not yet confirmed).
+
+## Other Key Commands (confirmed live)
+
+| Command | Index (hex) | Direction | Notes |
+|---------|-------------|-----------|-------|
+| battery_query | 0xD0 | query | battery |
+| anc_query | 0xCC | query | noise state |
+| anc_set | 0xC1 | set | [ancIndex][ancValue] |
+| device_state_query | 0xF2 | query | TWS state |
+| version_query | 0xC6 | query | version |
+| name_query | 0xC9 | query | device name |
+| device_function_query | 0xD8 | query | capabilities bitmap |
+| game_state_query | 0x08 | query | game mode |
+
+## Device Name
+
+- Bluetooth name confirmed: `EDIFIER W860NB Pro`
+
+## Notes for HyperEars Integration
+
+1. W860NB PRO is a **headphone** (formFactor = HEADPHONES)
+2. SPP UUID `EDF00000-EDFE-DFED-FEDF-EDFEDFEDFEDF` is primary, fallback RFCOMM channel 1
+3. Send header is `0xAA`, receive header is `0xBB` (older `0xCC`)
+4. CRC = sum of all preceding bytes & 0xFF — confirmed
+5. ANC values verified: 1=depth, 2=comfort, 3=wind, 4=ambient, 5=off
+6. **Send payloads are also XOR-0xA5-encrypted** (not just responses)
+7. The W860NB PRO executes ANC writes immediately; HyperEars skips the readback
+   round-trip to keep control latency low

--- a/docs/edifier-bes-protocol.md
+++ b/docs/edifier-bes-protocol.md
@@ -2,6 +2,14 @@
 
 > Verified on real hardware: Edifier W860NB PRO via LSPosed hook of Edifier Connect v8.4.39
 > Initial analysis from APK reverse engineering; frame format and ANC mapping confirmed by live capture.
+>
+> **Evidence levels:**
+> - **W860NB PRO** — Full real-device verification (ANC, battery, capabilities, SPP framing)
+> - **Other Edifier models (W820NB, W830NB, STAX, etc.)** — Based on BES/Edifier family protocol
+>   speculation, **not yet verified on real hardware**. The same SPP UUID, channel 1, XOR 0xA5
+>   encryption, and D0/CC/D8 commands are shared across the family, but individual firmware versions
+>   may differ in channel, encryption, command set, and response structure. Contributions and Issue
+>   reports for specific models are welcome.
 
 ## SPP Connection
 

--- a/docs/release-signing.md
+++ b/docs/release-signing.md
@@ -12,7 +12,7 @@ SHA-256: 3C:ED:7C:0E:E4:D3:0F:2B:12:5C:06:CE:51:C2:75:B7:96:39:B4:AB:99:5C:4F:0F
 安装后可以用 Android SDK `apksigner` 检查下载文件：
 
 ```powershell
-apksigner verify --verbose --print-certs .\HyperEars-v0.10.4.apk
+apksigner verify --verbose --print-certs .\HyperEars-v0.11.0.apk
 ```
 
 输出的 `Signer #1 certificate SHA-256 digest` 必须等于：

--- a/docs/system-module-architecture.md
+++ b/docs/system-module-architecture.md
@@ -85,9 +85,12 @@ EarbudAdapter
        │    ├─ OppoEncoFree4Adapter
        │    ├─ OppoEncoX3Adapter
        │    └─ OppoEncoAir5Adapter
-       └─ BoseEarbudAdapter
-            └─ BoseHeadphonesAdapter
-                └─ BoseQuietComfortHeadphonesAdapter
+       ├─ BoseEarbudAdapter
+       │    └─ BoseHeadphonesAdapter
+       │        └─ BoseQuietComfortHeadphonesAdapter
+       └─ EdifierEarbudAdapter
+            └─ EdifierHeadphonesAdapter
+                └─ EdifierW860NBProAdapter
 ```
 
 子类继承父类的通用能力，只覆盖经实机确认的差异：
@@ -107,6 +110,10 @@ EarbudAdapter
 - `BoseEarbudAdapter` 使用已连接耳机的名称/Bose OUI 做无扫描初筛，创建
   BMAP 会话后以 `[0.3]` 确认产品 ID，以 `[2.2]` 读取组件电量。名称只允许
   进入家族层；只有协议内产品 ID 才能升级到具体 Bose 型号。
+- `EdifierEarbudAdapter` 使用名称命中 Edifier/漫步者系标志，连接 SPP
+  `EDF00000-...` 或 channel 1，读取电量、ANC 状态和设备能力。头戴家族按
+  Bluetooth Class 区分形态；W860NB PRO 具体型号使用经实机确认的
+  XOR `0xA5` 加密 ANC 写入，一次设置即生效（不额外回查）。
 
 Registry 固定按“具体型号 → 厂商家族 → 标准耳机”解析：
 

--- a/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
@@ -84,6 +84,8 @@ object EarbudAdapterRegistry {
     private val oppoFamilyAdapter = OppoEarbudAdapter()
     private val boseFamilyAdapter = BoseEarbudAdapter()
     private val boseHeadphonesAdapter = BoseHeadphonesAdapter()
+    private val edifierFamilyAdapter = EdifierEarbudAdapter()
+    private val edifierHeadphonesAdapter = EdifierHeadphonesAdapter()
     private val standardAdapter = StandardEarbudAdapter()
 
     val adapters: List<EarbudAdapter> = listOf(
@@ -100,6 +102,9 @@ object EarbudAdapterRegistry {
         BoseQuietComfortHeadphonesAdapter,
         boseHeadphonesAdapter,
         boseFamilyAdapter,
+        EdifierW860NBProAdapter,
+        edifierHeadphonesAdapter,
+        edifierFamilyAdapter,
         standardAdapter,
     )
 

--- a/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
@@ -41,9 +41,11 @@ abstract class EarbudAdapter {
 
     open val capabilities: EarbudCapabilities = EarbudCapabilities()
     open val miLinkCardPresentationId: MiLinkCardPresentationId? = null
+
     /** Ordered transport candidates owned by this model adapter. */
     open val transports: List<EarbudTransportSpec> = emptyList()
-/** Minimum ms between ANC switch commands; 0 = no cooldown. */
+
+    /** Minimum ms between ANC switch commands; 0 = no cooldown. */
     open val ancSwitchCooldownMs: Long = 0L
 
     abstract fun matches(identity: EarbudIdentity): Boolean

--- a/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
@@ -43,6 +43,8 @@ abstract class EarbudAdapter {
     open val miLinkCardPresentationId: MiLinkCardPresentationId? = null
     /** Ordered transport candidates owned by this model adapter. */
     open val transports: List<EarbudTransportSpec> = emptyList()
+/** Minimum ms between ANC switch commands; 0 = no cooldown. */
+    open val ancSwitchCooldownMs: Long = 0L
 
     abstract fun matches(identity: EarbudIdentity): Boolean
 

--- a/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
@@ -14,7 +14,7 @@ open class EdifierEarbudAdapter : StandardEarbudAdapter() {
     override val displayName: String = "Edifier headset"
     override val privateProtocolRequired: Boolean = true
     override val batterySource: BatterySource = BatterySource.PRIVATE_PROTOCOL
-    override val endpoints: List<RfcommEndpointSpec> = listOf(
+    override val transports: List<EarbudTransportSpec> = listOf(
         RfcommEndpointSpec.ServiceUuid(
             uuid = EDF_SPP_UUID,
             id = "edifier-spp-uuid",
@@ -86,9 +86,11 @@ open class EdifierHeadphonesAdapter : EdifierEarbudAdapter() {
  */
 object EdifierW860NBProAdapter : EdifierHeadphonesAdapter() {
     const val ID = "edifier-w860nb-pro"
+    val PRESENTATION_ID = MiLinkCardPresentationId(ID)
 
     override val id: String = ID
     override val displayName: String = "Edifier W860NB PRO"
+    override val miLinkCardPresentationId: MiLinkCardPresentationId = PRESENTATION_ID
     override val capabilities: EarbudCapabilities = EarbudCapabilities(
         battery = true,
         noiseControl = true,
@@ -104,10 +106,16 @@ object EdifierW860NBProAdapter : EdifierHeadphonesAdapter() {
     override val noiseControlConfirmation: ControlConfirmationPolicy =
         ControlConfirmationPolicy.PUBLISH_AFTER_WRITE
 
-    override fun matches(identity: EarbudIdentity): Boolean {
-        val name = normalizeDeviceName(identity.deviceName.orEmpty())
-        return name.contains("w860nbpro") || name.contains("w860nb")
-    }
+    /**
+     * The W860NB PRO plays a voice prompt for ~1.9 s after an ANC switch and ignores commands
+     * during the prompt. Refuse new switches in the MiLink hook so the UI stays on the current
+     * mode instead of jumping to one the headset never applied.
+     */
+    override val ancSwitchCooldownMs: Long = 1_800L
+
+    override fun matches(identity: EarbudIdentity): Boolean =
+        super.matches(identity) &&
+            normalizeDeviceName(identity.deviceName.orEmpty()) == "edifierw860nbpro"
 }
 
 /**

--- a/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
@@ -1,0 +1,224 @@
+package dev.hyperears.integration
+
+import dev.hyperears.protocol.edifier.EdifierWireCodec
+
+/**
+ * Shared Edifier (BES/恒玄) headset behavior.
+ *
+ * Family detection is passive: the Bluetooth name is read from the already-connected system
+ * device. The private channel then queries device capabilities and battery through Edifier's
+ * proprietary SPP protocol.
+ */
+open class EdifierEarbudAdapter : StandardEarbudAdapter() {
+    override val id: String = ID
+    override val displayName: String = "Edifier headset"
+    override val privateProtocolRequired: Boolean = true
+    override val batterySource: BatterySource = BatterySource.PRIVATE_PROTOCOL
+    override val endpoints: List<RfcommEndpointSpec> = listOf(
+        RfcommEndpointSpec.ServiceUuid(
+            uuid = EDF_SPP_UUID,
+            id = "edifier-spp-uuid",
+        ),
+        RfcommEndpointSpec.Channel(number = 1),
+    )
+
+    override fun matches(identity: EarbudIdentity): Boolean {
+        if (!identity.standardHeadset || identity.nativeSystemEarbud) return false
+        val name = normalizeDeviceName(identity.deviceName.orEmpty())
+        return EDIFIER_NAME_MARKERS.any(name::contains)
+    }
+
+    override fun createProtocol(): EarbudProtocol =
+        EdifierEarbudProtocol()
+
+    companion object {
+        const val ID = "edifier-family"
+        const val EDF_SPP_UUID = "EDF00000-EDFE-DFED-FEDF-EDFEDFEDFEDF"
+
+        private val EDIFIER_NAME_MARKERS = setOf(
+            "edifier",
+            "w860nb",
+            "w820nb",
+            "w830nb",
+        )
+    }
+}
+
+/**
+ * Edifier over-ear headphones family.
+ *
+ * The W860NB PRO is a headphones form factor. Bluetooth device class or name markers
+ * distinguish headphones from TWS earbuds.
+ */
+open class EdifierHeadphonesAdapter : EdifierEarbudAdapter() {
+    override val id: String = ID
+    override val displayName: String = "Edifier headphones"
+    override val formFactor: HeadsetFormFactor = HeadsetFormFactor.HEADPHONES
+
+    override fun matches(identity: EarbudIdentity): Boolean =
+        super.matches(identity) && (
+            identity.bluetoothDeviceClass == BLUETOOTH_DEVICE_CLASS_HEADPHONES ||
+                normalizeDeviceName(identity.deviceName.orEmpty()).let { name ->
+                    HEADPHONE_MARKERS.any(name::contains)
+                }
+        )
+
+    companion object {
+        const val ID = "edifier-headphones-family"
+
+        // android.bluetooth.BluetoothClass.Device.AUDIO_VIDEO_HEADPHONES
+        const val BLUETOOTH_DEVICE_CLASS_HEADPHONES = 0x0418
+
+        private val HEADPHONE_MARKERS = setOf(
+            "w860nb",
+            "w820nb",
+            "w830nb",
+            "stax",
+        )
+    }
+}
+
+/**
+ * Concrete model adapter for Edifier W860NB PRO.
+ *
+ * Selected by exact normalized Bluetooth name match. The private protocol queries
+ * device capabilities (D8) and battery level after connection.
+ */
+object EdifierW860NBProAdapter : EdifierHeadphonesAdapter() {
+    const val ID = "edifier-w860nb-pro"
+
+    override val id: String = ID
+    override val displayName: String = "Edifier W860NB PRO"
+    override val capabilities: EarbudCapabilities = EarbudCapabilities(
+        battery = true,
+        noiseControl = true,
+        windNoiseControl = true,
+        audioHandoff = true,
+    )
+    override val supportedNoiseModes: Set<NoiseMode> = setOf(
+        NoiseMode.ANC,
+        NoiseMode.TRANSPARENCY,
+        NoiseMode.WIND,
+        NoiseMode.OFF,
+    )
+    override val noiseControlConfirmation: ControlConfirmationPolicy =
+        ControlConfirmationPolicy.PUBLISH_AFTER_WRITE
+
+    override fun matches(identity: EarbudIdentity): Boolean {
+        val name = normalizeDeviceName(identity.deviceName.orEmpty())
+        return name.contains("w860nbpro") || name.contains("w860nb")
+    }
+}
+
+/**
+ * Edifier private protocol state machine.
+ *
+ * Uses the BES/恒玄 SPP framing to query battery, ANC state, and device capabilities.
+ * Frame format: [0xBB/0xCC][APP_CODE][CMD][LEN_H][LEN_L][PAYLOAD...][CRC8]
+ */
+private class EdifierEarbudProtocol : EarbudProtocol {
+    private val decoder = EdifierWireCodec.Decoder()
+    private var functionQueried = false
+
+    override fun initialReadCommands(): List<ByteArray> = listOf(
+        EdifierWireCodec.queryBattery,
+        EdifierWireCodec.queryAnc,
+        EdifierWireCodec.queryFunction,
+    )
+
+    override fun encode(request: ControlRequest): List<ByteArray> = when (request) {
+        ControlRequest.Refresh -> listOf(
+            EdifierWireCodec.queryBattery,
+            EdifierWireCodec.queryAnc,
+        )
+        is ControlRequest.SetNoiseMode -> {
+            val ancValue = request.mode.toEdifierAncValue()
+            if (ancValue != null) {
+                listOf(EdifierWireCodec.setAnc(ancValue = ancValue))
+            } else {
+                emptyList()
+            }
+        }
+    }
+
+    override fun readback(request: ControlRequest): List<ByteArray> = when (request) {
+        // The W860NB PRO executes ANC writes immediately and reports state via the write
+        // acknowledgement. Skip the extra readback round-trip to reduce perceived latency.
+        ControlRequest.Refresh -> emptyList()
+        is ControlRequest.SetNoiseMode -> emptyList()
+    }
+
+    override fun offer(bytes: ByteArray): List<EarbudEvent> = buildList {
+        decoder.offer(bytes).forEach { frame ->
+            EdifierWireCodec.parseBatteryState(frame)?.let { battery ->
+                add(
+                    EarbudEvent.BatteryChanged(
+                        EarbudBattery(
+                            overall = BatteryReading(battery.wholeUnit, charging = false),
+                        ),
+                    ),
+                )
+                return@forEach
+            }
+
+            EdifierWireCodec.parseAncState(frame)?.let { anc ->
+                // anc.mode = ancIndex (0x10), anc.level = ancValue (1-5)
+                val mode = anc.level?.toNoiseMode()
+                if (mode != null) {
+                    add(EarbudEvent.NoiseModeChanged(mode, acknowledged = true))
+                }
+                return@forEach
+            }
+
+            // Function query response (D8) — confirms device capabilities
+            if (frame.commandIndex == EdifierWireCodec.CMD_FUNCTION_QUERY) {
+                functionQueried = true
+                add(EarbudEvent.Handshake(accepted = true))
+                return@forEach
+            }
+
+            add(
+                EarbudEvent.UnknownFrame(
+                    version = 0,
+                    vendor = 0,
+                    command = frame.commandIndex,
+                    payloadSize = frame.payload.size,
+                ),
+            )
+        }
+    }
+
+    override fun reset() {
+        decoder.reset()
+        functionQueried = false
+    }
+
+    private fun NoiseMode.toEdifierAncValue(): Int? = when (this) {
+        // W860NB PRO uses ANC16 slot; 1=depth, 2=comfort, 3=wind, 4=ambient, 5=off
+        NoiseMode.ANC -> EdifierWireCodec.ANC_VALUE_DEEP
+        NoiseMode.WIND -> EdifierWireCodec.ANC_VALUE_WIND
+        NoiseMode.TRANSPARENCY -> EdifierWireCodec.ANC_VALUE_AMBIENT
+        NoiseMode.OFF -> EdifierWireCodec.ANC_VALUE_OFF
+    }
+
+    /**
+     * Map Edifier ANC response mode byte to HyperEars NoiseMode.
+     *
+     * Verified on W860NB PRO hardware:
+     * - 1: 深度降噪 (deep NC) -> ANC
+     * - 2: 舒适降噪 (comfort NC) -> ANC
+     * - 3: 防风噪 (wind noise) -> WIND
+     * - 4: 环境声 (ambient/transparency) -> TRANSPARENCY
+     * - 5: 降噪关 (NC off) -> OFF
+     */
+    private fun Int.toNoiseMode(): NoiseMode? = when (this) {
+        EdifierWireCodec.ANC_VALUE_DEEP,
+        EdifierWireCodec.ANC_VALUE_COMFORT,
+        -> NoiseMode.ANC
+
+        EdifierWireCodec.ANC_VALUE_WIND -> NoiseMode.WIND
+        EdifierWireCodec.ANC_VALUE_AMBIENT -> NoiseMode.TRANSPARENCY
+        EdifierWireCodec.ANC_VALUE_OFF -> NoiseMode.OFF
+        else -> null
+    }
+}

--- a/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
+++ b/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
@@ -24,12 +24,6 @@ class EarbudAdapterHierarchyTest {
             HeadsetFormFactor.HEADPHONES,
             BoseQuietComfortHeadphonesAdapter.formFactor,
         )
-        assertEquals(HeadsetFormFactor.TWS, EdifierEarbudAdapter().formFactor)
-        assertEquals(HeadsetFormFactor.HEADPHONES, EdifierHeadphonesAdapter().formFactor)
-        assertEquals(
-            HeadsetFormFactor.HEADPHONES,
-            EdifierW860NBProAdapter.formFactor,
-        )
     }
 
     @Test
@@ -115,34 +109,6 @@ class EarbudAdapterHierarchyTest {
                 identity("LE-Headset", standardHeadset = true),
             ) is StandardEarbudAdapter,
         )
-        // Edifier W860NB PRO resolves to the concrete model when the Bluetooth class is headphones.
-        assertEquals(
-            EdifierW860NBProAdapter,
-            EarbudAdapterRegistry.resolve(
-                identity(
-                    name = "EDIFIER W860NB Pro",
-                    standardHeadset = true,
-                    bluetoothDeviceClass =
-                        EdifierHeadphonesAdapter.BLUETOOTH_DEVICE_CLASS_HEADPHONES,
-                ),
-            ),
-        )
-        assertTrue(
-            EarbudAdapterRegistry.resolve(
-                identity(
-                    name = "EDIFIER W860NB Pro",
-                    standardHeadset = true,
-                    bluetoothDeviceClass =
-                        EdifierHeadphonesAdapter.BLUETOOTH_DEVICE_CLASS_HEADPHONES,
-                ),
-            ) is EdifierHeadphonesAdapter,
-        )
-        // A generic Edifier name without the headphones class stays on the family adapter.
-        assertTrue(
-            EarbudAdapterRegistry.resolve(
-                identity("EDIFIER STAX SPIRIT", standardHeadset = true),
-            ) is EdifierEarbudAdapter,
-        )
         assertNull(EarbudAdapterRegistry.resolve(identity("Living Room Speaker")))
         assertNull(EarbudAdapterRegistry.resolve(identity(null)))
         assertNull(
@@ -166,6 +132,7 @@ class EarbudAdapterHierarchyTest {
             setOf(
                 StarRingUltraAdapter.PRESENTATION_ID,
                 BoseQuietComfortHeadphonesAdapter.PRESENTATION_ID,
+                EdifierW860NBProAdapter.PRESENTATION_ID,
             ),
             presentationIds.toSet(),
         )
@@ -175,6 +142,8 @@ class EarbudAdapterHierarchyTest {
         assertNull(OppoEncoAir2ProAdapter.miLinkCardPresentationId)
         assertNull(BoseEarbudAdapter().miLinkCardPresentationId)
         assertNull(BoseHeadphonesAdapter().miLinkCardPresentationId)
+        assertNull(EdifierEarbudAdapter().miLinkCardPresentationId)
+        assertNull(EdifierHeadphonesAdapter().miLinkCardPresentationId)
         assertEquals(
             BoseQuietComfortHeadphonesAdapter.PRESENTATION_ID,
             BoseQuietComfortHeadphonesAdapter.miLinkCardPresentationId,
@@ -699,100 +668,6 @@ class EarbudAdapterHierarchyTest {
         assertEquals("FF 03 00 03 00 1B 01 30 00 04 00", anc.hex())
         assertEquals("FF 03 00 03 00 1B 01 30 01 04 00", off.hex())
         assertEquals("FF 03 00 03 00 1B 01 30 02 04 00", transparency.hex())
-    }
-
-    @Test
-    fun edifierW860NBProInheritsHeadphonesFamilyAndPublishesVerifiedCapabilities() {
-        assertEquals(
-            EdifierHeadphonesAdapter::class.java,
-            EdifierW860NBProAdapter.javaClass.superclass,
-        )
-        assertEquals(
-            EdifierEarbudAdapter::class.java,
-            EdifierHeadphonesAdapter::class.java.superclass,
-        )
-        assertEquals(
-            StandardEarbudAdapter::class.java,
-            EdifierEarbudAdapter::class.java.superclass,
-        )
-        assertEquals(
-            listOf("edifier-spp-uuid", "rfcomm-1"),
-            EdifierW860NBProAdapter.endpoints.map(RfcommEndpointSpec::id),
-        )
-        assertEquals(BatterySource.PRIVATE_PROTOCOL, EdifierW860NBProAdapter.batterySource)
-        assertTrue(EdifierW860NBProAdapter.privateProtocolRequired)
-        assertEquals(
-            setOf(NoiseMode.ANC, NoiseMode.TRANSPARENCY, NoiseMode.WIND, NoiseMode.OFF),
-            EdifierW860NBProAdapter.supportedNoiseModes,
-        )
-        assertEquals(
-            ControlConfirmationPolicy.PUBLISH_AFTER_WRITE,
-            EdifierW860NBProAdapter.noiseControlConfirmation,
-        )
-        assertTrue(EdifierW860NBProAdapter.capabilities.battery)
-        assertTrue(EdifierW860NBProAdapter.capabilities.noiseControl)
-        assertTrue(EdifierW860NBProAdapter.capabilities.windNoiseControl)
-        assertTrue(EdifierW860NBProAdapter.capabilities.audioHandoff)
-        assertNull(EdifierW860NBProAdapter.miLinkCardPresentationId)
-        assertNull(EdifierEarbudAdapter().miLinkCardPresentationId)
-    }
-
-    @Test
-    fun edifierProtocolUsesEncryptedAncWritesAndDecryptsResponses() {
-        val protocol = requireNotNull(EdifierW860NBProAdapter.createProtocol())
-
-        // Initial reads: battery, ANC state, device capabilities.
-        assertEquals(
-            listOf(
-                "AA EC D0 00 00 66",
-                "AA EC CC 00 00 62",
-                "AA EC D8 00 00 6E",
-            ),
-            protocol.initialReadCommands().map { it.hex() },
-        )
-
-        // ANC writes carry XOR-0xA5-encrypted payloads (verified on W860NB PRO).
-        assertEquals(
-            "AA EC C1 00 02 B5 A4 B2", // deep NC (10 01 -> B5 A4)
-            protocol.encode(ControlRequest.SetNoiseMode(NoiseMode.ANC)).single().hex(),
-        )
-        assertEquals(
-            "AA EC C1 00 02 B5 A1 AF", // ambient (10 04 -> B5 A1)
-            protocol.encode(ControlRequest.SetNoiseMode(NoiseMode.TRANSPARENCY)).single().hex(),
-        )
-        assertEquals(
-            "AA EC C1 00 02 B5 A0 AE", // NC off (10 05 -> B5 A0)
-            protocol.encode(ControlRequest.SetNoiseMode(NoiseMode.OFF)).single().hex(),
-        )
-
-        // No readback: the W860NB PRO executes writes immediately.
-        assertTrue(protocol.readback(ControlRequest.SetNoiseMode(NoiseMode.ANC)).isEmpty())
-
-        // Battery response: BB EC D0 00 01 9C 14 -> 0x9C ^ 0xA5 = 0x39 = 57%.
-        assertEquals(
-            listOf(
-                EarbudEvent.BatteryChanged(
-                    EarbudBattery(overall = BatteryReading(57, false)),
-                ),
-            ),
-            protocol.offer(hex("BB EC D0 00 01 9C 14")),
-        )
-
-        // ANC response: BB EC CC 00 02 B5 A0 CA -> 10 05 (NC off).
-        assertEquals(
-            listOf(EarbudEvent.NoiseModeChanged(NoiseMode.OFF, acknowledged = true)),
-            protocol.offer(hex("BB EC CC 00 02 B5 A0 CA")),
-        )
-        // ANC response for deep NC: BB EC CC 00 02 B5 A4 CE -> 10 01.
-        assertEquals(
-            listOf(EarbudEvent.NoiseModeChanged(NoiseMode.ANC, acknowledged = true)),
-            protocol.offer(hex("BB EC CC 00 02 B5 A4 CE")),
-        )
-        // ANC response for ambient: BB EC CC 00 02 B5 A1 CB -> 10 04.
-        assertEquals(
-            listOf(EarbudEvent.NoiseModeChanged(NoiseMode.TRANSPARENCY, acknowledged = true)),
-            protocol.offer(hex("BB EC CC 00 02 B5 A1 CB")),
-        )
     }
 
     private fun hex(value: String): ByteArray {

--- a/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
+++ b/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
@@ -152,6 +152,118 @@ class EarbudAdapterHierarchyTest {
     }
 
     @Test
+    fun edifierRegistryKeepsConcreteFamilyAndPlatformConstraintsDistinct() {
+        val concrete = identity(
+            name = "EDIFIER W860NB Pro",
+            standardHeadset = true,
+            bluetoothDeviceClass = EdifierHeadphonesAdapter.BLUETOOTH_DEVICE_CLASS_HEADPHONES,
+        )
+        assertEquals(EdifierW860NBProAdapter, EarbudAdapterRegistry.resolve(concrete))
+        assertTrue(
+            EarbudAdapterRegistry.resolve(
+                identity("EDIFIER W860NB", standardHeadset = true),
+            ) is EdifierHeadphonesAdapter,
+        )
+        assertTrue(
+            EarbudAdapterRegistry.resolve(
+                identity("EDIFIER NeoBuds", standardHeadset = true),
+            ) is EdifierEarbudAdapter,
+        )
+
+        assertFalse(
+            EdifierW860NBProAdapter.matches(
+                identity("EDIFIER W860NB", standardHeadset = true),
+            ),
+        )
+        assertFalse(
+            EdifierW860NBProAdapter.matches(
+                identity("EDIFIER W860NB Pro", standardHeadset = false),
+            ),
+        )
+        assertFalse(
+            EdifierW860NBProAdapter.matches(
+                identity(
+                    "EDIFIER W860NB Pro",
+                    standardHeadset = true,
+                    nativeSystemEarbud = true,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun edifierConcreteAdapterOwnsVerifiedTransportCapabilitiesAndProtocol() {
+        val adapter = EdifierW860NBProAdapter
+        assertEquals(HeadsetFormFactor.HEADPHONES, adapter.formFactor)
+        assertEquals(BatterySource.PRIVATE_PROTOCOL, adapter.batterySource)
+        assertEquals(
+            listOf("edifier-spp-uuid", "rfcomm-1"),
+            adapter.transports.map(EarbudTransportSpec::id),
+        )
+        assertTrue(adapter.capabilities.battery)
+        assertTrue(adapter.capabilities.noiseControl)
+        assertTrue(adapter.capabilities.windNoiseControl)
+        assertTrue(adapter.capabilities.audioHandoff)
+        assertEquals(
+            setOf(
+                NoiseMode.ANC,
+                NoiseMode.TRANSPARENCY,
+                NoiseMode.WIND,
+                NoiseMode.OFF,
+            ),
+            adapter.supportedNoiseModes,
+        )
+        assertEquals(
+            ControlConfirmationPolicy.PUBLISH_AFTER_WRITE,
+            adapter.noiseControlConfirmation,
+        )
+        assertEquals(1_800L, adapter.ancSwitchCooldownMs)
+
+        val protocol = requireNotNull(adapter.createProtocol())
+        assertEquals(
+            listOf("AA EC D0 00 00 66", "AA EC CC 00 00 62", "AA EC D8 00 00 6E"),
+            protocol.initialReadCommands().map { it.hex() },
+        )
+        assertEquals(
+            "AA EC C1 00 02 B5 A4 B2",
+            protocol.encode(ControlRequest.SetNoiseMode(NoiseMode.ANC)).single().hex(),
+        )
+        assertEquals(
+            "AA EC C1 00 02 B5 A6 B4",
+            protocol.encode(ControlRequest.SetNoiseMode(NoiseMode.WIND)).single().hex(),
+        )
+        assertEquals(
+            "AA EC C1 00 02 B5 A1 AF",
+            protocol
+                .encode(ControlRequest.SetNoiseMode(NoiseMode.TRANSPARENCY))
+                .single()
+                .hex(),
+        )
+        assertEquals(
+            "AA EC C1 00 02 B5 A0 AE",
+            protocol.encode(ControlRequest.SetNoiseMode(NoiseMode.OFF)).single().hex(),
+        )
+        assertTrue(protocol.readback(ControlRequest.SetNoiseMode(NoiseMode.WIND)).isEmpty())
+
+        assertEquals(
+            listOf(
+                EarbudEvent.BatteryChanged(
+                    EarbudBattery(overall = BatteryReading(60, false)),
+                ),
+                EarbudEvent.NoiseModeChanged(NoiseMode.OFF, acknowledged = true),
+                EarbudEvent.Handshake(accepted = true),
+            ),
+            protocol.offer(
+                hex(
+                    "BB EC D0 00 01 99 11 " +
+                        "BB EC CC 00 02 B5 A0 CA " +
+                        "BB EC D8 00 00 7F",
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun vivoFamilyOwnsCommonProtocolWhileStandardRemainsIdentityOnly() {
         assertEquals(
             VivoTwsAir3ProAdapter,

--- a/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
+++ b/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
@@ -24,6 +24,12 @@ class EarbudAdapterHierarchyTest {
             HeadsetFormFactor.HEADPHONES,
             BoseQuietComfortHeadphonesAdapter.formFactor,
         )
+        assertEquals(HeadsetFormFactor.TWS, EdifierEarbudAdapter().formFactor)
+        assertEquals(HeadsetFormFactor.HEADPHONES, EdifierHeadphonesAdapter().formFactor)
+        assertEquals(
+            HeadsetFormFactor.HEADPHONES,
+            EdifierW860NBProAdapter.formFactor,
+        )
     }
 
     @Test
@@ -108,6 +114,34 @@ class EarbudAdapterHierarchyTest {
             EarbudAdapterRegistry.resolve(
                 identity("LE-Headset", standardHeadset = true),
             ) is StandardEarbudAdapter,
+        )
+        // Edifier W860NB PRO resolves to the concrete model when the Bluetooth class is headphones.
+        assertEquals(
+            EdifierW860NBProAdapter,
+            EarbudAdapterRegistry.resolve(
+                identity(
+                    name = "EDIFIER W860NB Pro",
+                    standardHeadset = true,
+                    bluetoothDeviceClass =
+                        EdifierHeadphonesAdapter.BLUETOOTH_DEVICE_CLASS_HEADPHONES,
+                ),
+            ),
+        )
+        assertTrue(
+            EarbudAdapterRegistry.resolve(
+                identity(
+                    name = "EDIFIER W860NB Pro",
+                    standardHeadset = true,
+                    bluetoothDeviceClass =
+                        EdifierHeadphonesAdapter.BLUETOOTH_DEVICE_CLASS_HEADPHONES,
+                ),
+            ) is EdifierHeadphonesAdapter,
+        )
+        // A generic Edifier name without the headphones class stays on the family adapter.
+        assertTrue(
+            EarbudAdapterRegistry.resolve(
+                identity("EDIFIER STAX SPIRIT", standardHeadset = true),
+            ) is EdifierEarbudAdapter,
         )
         assertNull(EarbudAdapterRegistry.resolve(identity("Living Room Speaker")))
         assertNull(EarbudAdapterRegistry.resolve(identity(null)))
@@ -665,6 +699,100 @@ class EarbudAdapterHierarchyTest {
         assertEquals("FF 03 00 03 00 1B 01 30 00 04 00", anc.hex())
         assertEquals("FF 03 00 03 00 1B 01 30 01 04 00", off.hex())
         assertEquals("FF 03 00 03 00 1B 01 30 02 04 00", transparency.hex())
+    }
+
+    @Test
+    fun edifierW860NBProInheritsHeadphonesFamilyAndPublishesVerifiedCapabilities() {
+        assertEquals(
+            EdifierHeadphonesAdapter::class.java,
+            EdifierW860NBProAdapter.javaClass.superclass,
+        )
+        assertEquals(
+            EdifierEarbudAdapter::class.java,
+            EdifierHeadphonesAdapter::class.java.superclass,
+        )
+        assertEquals(
+            StandardEarbudAdapter::class.java,
+            EdifierEarbudAdapter::class.java.superclass,
+        )
+        assertEquals(
+            listOf("edifier-spp-uuid", "rfcomm-1"),
+            EdifierW860NBProAdapter.endpoints.map(RfcommEndpointSpec::id),
+        )
+        assertEquals(BatterySource.PRIVATE_PROTOCOL, EdifierW860NBProAdapter.batterySource)
+        assertTrue(EdifierW860NBProAdapter.privateProtocolRequired)
+        assertEquals(
+            setOf(NoiseMode.ANC, NoiseMode.TRANSPARENCY, NoiseMode.WIND, NoiseMode.OFF),
+            EdifierW860NBProAdapter.supportedNoiseModes,
+        )
+        assertEquals(
+            ControlConfirmationPolicy.PUBLISH_AFTER_WRITE,
+            EdifierW860NBProAdapter.noiseControlConfirmation,
+        )
+        assertTrue(EdifierW860NBProAdapter.capabilities.battery)
+        assertTrue(EdifierW860NBProAdapter.capabilities.noiseControl)
+        assertTrue(EdifierW860NBProAdapter.capabilities.windNoiseControl)
+        assertTrue(EdifierW860NBProAdapter.capabilities.audioHandoff)
+        assertNull(EdifierW860NBProAdapter.miLinkCardPresentationId)
+        assertNull(EdifierEarbudAdapter().miLinkCardPresentationId)
+    }
+
+    @Test
+    fun edifierProtocolUsesEncryptedAncWritesAndDecryptsResponses() {
+        val protocol = requireNotNull(EdifierW860NBProAdapter.createProtocol())
+
+        // Initial reads: battery, ANC state, device capabilities.
+        assertEquals(
+            listOf(
+                "AA EC D0 00 00 66",
+                "AA EC CC 00 00 62",
+                "AA EC D8 00 00 6E",
+            ),
+            protocol.initialReadCommands().map { it.hex() },
+        )
+
+        // ANC writes carry XOR-0xA5-encrypted payloads (verified on W860NB PRO).
+        assertEquals(
+            "AA EC C1 00 02 B5 A4 B2", // deep NC (10 01 -> B5 A4)
+            protocol.encode(ControlRequest.SetNoiseMode(NoiseMode.ANC)).single().hex(),
+        )
+        assertEquals(
+            "AA EC C1 00 02 B5 A1 AF", // ambient (10 04 -> B5 A1)
+            protocol.encode(ControlRequest.SetNoiseMode(NoiseMode.TRANSPARENCY)).single().hex(),
+        )
+        assertEquals(
+            "AA EC C1 00 02 B5 A0 AE", // NC off (10 05 -> B5 A0)
+            protocol.encode(ControlRequest.SetNoiseMode(NoiseMode.OFF)).single().hex(),
+        )
+
+        // No readback: the W860NB PRO executes writes immediately.
+        assertTrue(protocol.readback(ControlRequest.SetNoiseMode(NoiseMode.ANC)).isEmpty())
+
+        // Battery response: BB EC D0 00 01 9C 14 -> 0x9C ^ 0xA5 = 0x39 = 57%.
+        assertEquals(
+            listOf(
+                EarbudEvent.BatteryChanged(
+                    EarbudBattery(overall = BatteryReading(57, false)),
+                ),
+            ),
+            protocol.offer(hex("BB EC D0 00 01 9C 14")),
+        )
+
+        // ANC response: BB EC CC 00 02 B5 A0 CA -> 10 05 (NC off).
+        assertEquals(
+            listOf(EarbudEvent.NoiseModeChanged(NoiseMode.OFF, acknowledged = true)),
+            protocol.offer(hex("BB EC CC 00 02 B5 A0 CA")),
+        )
+        // ANC response for deep NC: BB EC CC 00 02 B5 A4 CE -> 10 01.
+        assertEquals(
+            listOf(EarbudEvent.NoiseModeChanged(NoiseMode.ANC, acknowledged = true)),
+            protocol.offer(hex("BB EC CC 00 02 B5 A4 CE")),
+        )
+        // ANC response for ambient: BB EC CC 00 02 B5 A1 CB -> 10 04.
+        assertEquals(
+            listOf(EarbudEvent.NoiseModeChanged(NoiseMode.TRANSPARENCY, acknowledged = true)),
+            protocol.offer(hex("BB EC CC 00 02 B5 A1 CB")),
+        )
     }
 
     private fun hex(value: String): ByteArray {

--- a/protocol-test/src/main/java/dev/hyperears/protocoltest/MainActivity.kt
+++ b/protocol-test/src/main/java/dev/hyperears/protocoltest/MainActivity.kt
@@ -421,6 +421,9 @@ private fun ConnectionCard(
 
                             ProtocolTarget.BOSE_BMAP ->
                                 "将依次探测通道 8、SPP、BMAP UUID、兼容通道 2"
+
+                            ProtocolTarget.EDIFIER_BES ->
+                                "将依次探测 Edifier SPP UUID、通道 1、标准 SPP"
                         },
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -873,15 +876,23 @@ private fun ApiTestCard(
 
             ProtocolTarget.BOSE_BMAP ->
                 "先读取 BMAP 产品 ID，再读取 [2.2] 组件电量；两条命令均为只读。"
+
+            ProtocolTarget.EDIFIER_BES ->
+                "发送 Edifier 电量、降噪状态和设备功能查询，不改变耳机设置。"
         },
     ) {
-        if (target == ProtocolTarget.VIVO_TWS || target == ProtocolTarget.BOSE_BMAP) {
+        if (target == ProtocolTarget.VIVO_TWS || target == ProtocolTarget.BOSE_BMAP ||
+            target == ProtocolTarget.EDIFIER_BES) {
             ApiStatusRow(
-                if (target == ProtocolTarget.BOSE_BMAP) "产品判型" else "握手",
+                when (target) {
+                    ProtocolTarget.BOSE_BMAP -> "产品判型"
+                    ProtocolTarget.EDIFIER_BES -> "设备功能"
+                    else -> "握手"
+                },
                 handshakeStatus,
             )
         }
-        if (target == ProtocolTarget.VIVO_TWS) {
+        if (target == ProtocolTarget.VIVO_TWS || target == ProtocolTarget.EDIFIER_BES) {
             ApiStatusRow("降噪查询", noiseStatus)
         }
         ApiStatusRow("电量查询", batteryStatus)
@@ -895,6 +906,7 @@ private fun ApiTestCard(
                     ProtocolTarget.VIVO_TWS -> "运行完整只读探测"
                     ProtocolTarget.STARRING_ULTRA -> "查询 StarRing 电量"
                     ProtocolTarget.BOSE_BMAP -> "读取 Bose 型号与电量"
+                    ProtocolTarget.EDIFIER_BES -> "运行 Edifier 只读探测"
                 },
             )
         }
@@ -986,6 +998,9 @@ private fun RawCommandCard(
 
             ProtocolTarget.BOSE_BMAP ->
                 "高级诊断入口；输入完整 BMAP 帧，例如电量只读请求 02 02 01 00。"
+
+            ProtocolTarget.EDIFIER_BES ->
+                "高级诊断入口；输入完整 Edifier BES 帧，例如电量查询 BB EC D0 00 00 xx。"
         },
     ) {
         OutlinedTextField(

--- a/protocol-test/src/main/java/dev/hyperears/protocoltest/ProtocolTestViewModel.kt
+++ b/protocol-test/src/main/java/dev/hyperears/protocoltest/ProtocolTestViewModel.kt
@@ -11,6 +11,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import dev.hyperears.protocol.bose.BoseBmapWireCodec
+import dev.hyperears.protocol.edifier.EdifierWireCodec
 import dev.hyperears.protocol.starring.StarRingWireCodec
 import dev.hyperears.protocol.vivo.VivoTwsProtocol
 import dev.hyperears.protocol.vivo.VivoTwsProtocol.NoiseMode
@@ -116,6 +117,7 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
     private val vivoDecoder = VivoTwsProtocol.Decoder()
     private val starRingDecoder = StarRingWireCodec.Decoder()
     private val boseDecoder = BoseBmapWireCodec.Decoder()
+    private val edifierDecoder = EdifierWireCodec.Decoder()
     private val mutableState = MutableStateFlow(ProtocolUiState())
     val state: StateFlow<ProtocolUiState> = mutableState.asStateFlow()
     private val logId = AtomicLong()
@@ -123,6 +125,17 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
     private var connectionJob: Job? = null
     private var identityScanTimeoutJob: Job? = null
     private var activeTransport = ActiveTransport.NONE
+
+    /** File log writer — mirrors every UI log line to the app's private storage for external reading. */
+    private val fileLog: java.io.FileWriter? by lazy {
+        runCatching {
+            val file = java.io.File(application.filesDir, "probe.log")
+            java.io.FileWriter(file, true).also { writer ->
+                writer.write("\n=== HyperEars Protocol Lab Session ${SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US).format(Date())} ===\n")
+                writer.flush()
+            }
+        }.getOrNull()
+    }
 
     init {
         viewModelScope.launch {
@@ -261,6 +274,7 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
             vivoDecoder.reset()
             starRingDecoder.reset()
             boseDecoder.reset()
+            edifierDecoder.reset()
             val target = mutableState.value.selectedTarget
             mutableState.value = mutableState.value.copy(
                 phase = ConnectionPhase.CONNECTING,
@@ -350,6 +364,18 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
                     delay(PROBE_GAP_MS)
                     send(BoseBmapWireCodec.queryBattery, "Bose 查询组件电量")
                 }
+                ProtocolTarget.EDIFIER_BES -> {
+                    mutableState.value = mutableState.value.copy(
+                        handshakeStatus = "等待设备功能响应",
+                        noiseApiStatus = "等待响应",
+                        batteryApiStatus = "等待响应",
+                    )
+                    send(EdifierWireCodec.queryBattery, "Edifier 查询电量")
+                    delay(PROBE_GAP_MS)
+                    send(EdifierWireCodec.queryAnc, "Edifier 查询降噪状态")
+                    delay(PROBE_GAP_MS)
+                    send(EdifierWireCodec.queryFunction, "Edifier 查询设备功能")
+                }
             }
             markTimeoutsLater()
         }
@@ -410,6 +436,9 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
 
                 ProtocolTarget.BOSE_BMAP ->
                     send(BoseBmapWireCodec.queryBattery, "Bose 查询组件电量")
+
+                ProtocolTarget.EDIFIER_BES ->
+                    send(EdifierWireCodec.queryBattery, "Edifier 查询电量")
             }
             markTimeoutsLater()
         }
@@ -579,6 +608,7 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
             ProtocolTarget.VIVO_TWS -> handleVivoIncoming(bytes)
             ProtocolTarget.STARRING_ULTRA -> handleStarRingIncoming(bytes)
             ProtocolTarget.BOSE_BMAP -> handleBoseIncoming(bytes)
+            ProtocolTarget.EDIFIER_BES -> handleEdifierIncoming(bytes)
         }
     }
 
@@ -696,6 +726,52 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
                         "右=${battery.rightPercent ?: "—"}% 盒=${battery.casePercent ?: "—"}%",
                     BoseBmapWireCodec.run { battery.rawPayload.hex() },
                 )
+            }
+        }
+    }
+
+    private fun handleEdifierIncoming(bytes: ByteArray) {
+        edifierDecoder.offer(bytes).forEach { frame ->
+            addLog(
+                "FRAME",
+                "Edifier header=0x${frame.header.hex2()} appCode=0x${frame.appCode.hex2()} " +
+                    "cmd=0x${frame.commandIndex.hex2()} payload=${frame.payload.size}",
+                EdifierWireCodec.run { frame.bytes.hex() },
+            )
+            EdifierWireCodec.parseBatteryState(frame)?.let { battery ->
+                mutableState.value = mutableState.value.copy(
+                    battery = BatteryObservation(
+                        leftPercent = battery.wholeUnit,
+                        rightPercent = battery.wholeUnit,
+                        casePercent = null,
+                    ),
+                    batteryApiStatus = "可用 · Edifier 响应",
+                )
+                addLog("BAT", "电量=${battery.wholeUnit ?: "—"}%")
+            }
+            EdifierWireCodec.parseAncState(frame)?.let { anc ->
+                val modeLabel = when (anc.mode) {
+                    EdifierWireCodec.ANC_INDEX -> when (anc.level) {
+                        EdifierWireCodec.ANC_VALUE_DEEP -> "深度降噪"
+                        EdifierWireCodec.ANC_VALUE_COMFORT -> "舒适降噪"
+                        EdifierWireCodec.ANC_VALUE_WIND -> "防风噪"
+                        EdifierWireCodec.ANC_VALUE_AMBIENT -> "环境声"
+                        EdifierWireCodec.ANC_VALUE_OFF -> "降噪关"
+                        else -> "未知值(${anc.level})"
+                    }
+                    else -> "未知index(${anc.mode})"
+                }
+                mutableState.value = mutableState.value.copy(
+                    noiseApiStatus = "可用 · $modeLabel",
+                )
+                addLog("ANC", "ancIndex=${anc.mode} ancValue=${anc.level} → $modeLabel")
+            }
+            // D8 function query response
+            if (frame.commandIndex == EdifierWireCodec.CMD_FUNCTION_QUERY && frame.payload.isNotEmpty()) {
+                mutableState.value = mutableState.value.copy(
+                    handshakeStatus = "可用 · D8 功能响应 ${frame.payload.size} 字节",
+                )
+                addLog("FUNC", "设备功能响应: ${frame.payload.size} 字节", EdifierWireCodec.run { frame.payload.hex() })
             }
         }
     }
@@ -841,7 +917,13 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
             message = message,
             hex = hex,
         )
-        Log.d(TAG, "[$direction] $message${hex?.let { " | $it" }.orEmpty()}")
+        val line = "[$direction] $message${hex?.let { " | $it" }.orEmpty()}"
+        Log.d(TAG, line)
+        // Mirror to private file for external reading via run-as
+        runCatching {
+            fileLog?.appendLine("${entry.time} $line")
+            fileLog?.flush()
+        }
         mutableState.value = mutableState.value.copy(
             logs = (listOf(entry) + mutableState.value.logs).take(MAX_LOGS),
         )

--- a/protocol-test/src/main/java/dev/hyperears/protocoltest/RfcommProbeClient.kt
+++ b/protocol-test/src/main/java/dev/hyperears/protocoltest/RfcommProbeClient.kt
@@ -152,6 +152,27 @@ internal enum class ProtocolTarget(
             ),
         ),
     ),
+    EDIFIER_BES(
+        label = "Edifier BES",
+        endpoints = listOf(
+            RfcommEndpoint.ServiceUuid(
+                uuid = UUID.fromString("EDF00000-EDFE-DFED-FEDF-EDFEDFEDFEDF"),
+                id = "edifier-spp",
+                label = "Edifier SPP UUID",
+            ),
+            RfcommEndpoint.Channel(
+                number = 1,
+                secure = true,
+                id = "rfcomm-1",
+                label = "RFCOMM 通道 1（Edifier 回退）",
+            ),
+            RfcommEndpoint.ServiceUuid(
+                uuid = STANDARD_SPP_UUID,
+                id = "standard-spp",
+                label = "标准 SPP UUID",
+            ),
+        ),
+    ),
     ;
 
     companion object {
@@ -169,6 +190,11 @@ internal enum class ProtocolTarget(
 
                 (normalized.contains("vivo") || normalized.contains("iqoo")) &&
                     (normalized.contains("tws") || normalized.contains("air")) -> VIVO_TWS
+
+                normalized.contains("edifier") ||
+                    normalized.contains("w860nb") ||
+                    normalized.contains("w820nb") ||
+                    normalized.contains("w830nb") -> EDIFIER_BES
 
                 else -> null
             }

--- a/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
+++ b/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
@@ -1,0 +1,242 @@
+package dev.hyperears.protocol.edifier
+
+/**
+ * Edifier (BES/恒玄) command framing carried over its private Bluetooth Classic RFCOMM service.
+ *
+ * Protocol verified on real hardware (Edifier W860NB PRO via LSPosed hook of Edifier Connect v8.4.39):
+ *
+ * Frame format (BLE v2):
+ * - Send:   [0xAA][APP_CODE=0xEC][CMD_INDEX][LEN_H][LEN_L][PAYLOAD...][CRC8]
+ * - Receive: [0xBB][APP_CODE][CMD_INDEX][LEN_H][LEN_L][PAYLOAD...][CRC8]  (older: 0xCC)
+ *
+ * CRC: sum of all preceding bytes & 0xFF (verified: AA+EC+D8+00+00 = 0x26E -> &0xFF = 0x6E)
+ * Payload is plaintext on SEND. ANC set payload is [ancIndex][ancValue].
+ */
+object EdifierWireCodec {
+    const val SEND_HEADER = 0xAA
+    const val RECEIVE_HEADER = 0xBB
+    const val RECEIVE_HEADER_OLD = 0xCC
+    const val APP_CODE = 0xEC
+
+    /**
+     * XOR key for response payload encryption (Encryption10).
+     * From ECCommand.EncryptionCode: Encryption10.value = Opcodes.IF_ACMPEQ = 165 = 0xA5.
+     * Verified: battery response 0x99 ^ 0xA5 = 0x3C = 60%.
+     */
+    const val RESPONSE_XOR_KEY = 0xA5
+
+    // Command indices (verified from Edifier Connect App + real device)
+    const val CMD_BATTERY_QUERY = 0xD0        // 208 — query battery
+    const val CMD_ANC_QUERY = 0xCC            // 204 — query ANC/noise state
+    const val CMD_ANC_SET = 0xC1              // 193 — set ANC mode
+    const val CMD_DEVICE_STATE_QUERY = 0xF2   // 242 — query TWS/device state
+    const val CMD_VERSION_QUERY = 0xC6        // 198 — query version
+    const val CMD_NAME_QUERY = 0xC9           // 201 — query name
+    const val CMD_FUNCTION_QUERY = 0xD8       // 216 — query device capabilities
+    const val CMD_GAME_STATE_QUERY = 0x08     // 8   — query game mode
+
+    // ANC ancIndex for W860NB PRO (ANC16 slot, verified on device)
+    const val ANC_INDEX = 0x10
+
+    // ANC ancValue mapping (verified on device):
+    // 1=deep noise cancelling, 2=comfort NC, 3=wind noise, 4=ambient, 5=NC off
+    const val ANC_VALUE_DEEP = 1
+    const val ANC_VALUE_COMFORT = 2
+    const val ANC_VALUE_WIND = 3
+    const val ANC_VALUE_AMBIENT = 4
+    const val ANC_VALUE_OFF = 5
+
+    data class Frame(
+        val header: Int,
+        val appCode: Int,
+        val commandIndex: Int,
+        val payload: ByteArray,
+        val bytes: ByteArray,
+    )
+
+    data class BatteryState(
+        val wholeUnit: Int?,
+    )
+
+    data class AncState(
+        val mode: Int,
+        val level: Int?,
+    )
+
+    // ── Pre-built query packets ──
+
+    val queryBattery: ByteArray = packet(CMD_BATTERY_QUERY)
+    val queryAnc: ByteArray = packet(CMD_ANC_QUERY)
+    val queryDeviceState: ByteArray = packet(CMD_DEVICE_STATE_QUERY)
+    val queryFunction: ByteArray = packet(CMD_FUNCTION_QUERY)
+    val queryVersion: ByteArray = packet(CMD_VERSION_QUERY)
+
+    fun setAnc(ancValue: Int, ancIndex: Int = ANC_INDEX): ByteArray =
+        packet(
+            CMD_ANC_SET,
+            byteArrayOf(ancIndex.toByte(), ancValue.toByte()),
+            xorKey = RESPONSE_XOR_KEY,
+        )
+
+    // ── Parsing ──
+
+    /**
+     * Parse a battery response. Response payload is XOR-encrypted with [RESPONSE_XOR_KEY].
+     * Verified: `BB EC D0 00 01 99 11` -> payload[0]=0x99 -> 0x99^0xA5 = 0x3C = 60%.
+     */
+    fun parseBatteryState(frame: Frame): BatteryState? {
+        if (frame.commandIndex != CMD_BATTERY_QUERY && frame.commandIndex != CMD_DEVICE_STATE_QUERY) {
+            return null
+        }
+        if (frame.payload.isEmpty()) return null
+        val whole = (frame.payload[0].unsigned() xor RESPONSE_XOR_KEY)
+        if (whole !in 0..100) return null
+        return BatteryState(wholeUnit = whole)
+    }
+
+    /**
+     * Parse an ANC response. Response payload is XOR-encrypted with [RESPONSE_XOR_KEY].
+     * Verified: `BB EC CC 00 02 B5 A0 CA` -> payload=[0xB5,0xA0] -> XOR 0xA5 = [0x10, 0x05]
+     * -> ancIndex=16, ancValue=5 (NC off).
+     */
+    fun parseAncState(frame: Frame): AncState? {
+        if (frame.commandIndex != CMD_ANC_QUERY && frame.commandIndex != CMD_ANC_SET) {
+            return null
+        }
+        if (frame.payload.isEmpty()) return null
+        val mode = (frame.payload[0].unsigned() xor RESPONSE_XOR_KEY)
+        val level = frame.payload.getOrNull(1)?.unsigned()?.let { it xor RESPONSE_XOR_KEY }
+        return AncState(mode = mode, level = level)
+    }
+
+    // ── Frame building ──
+
+    fun packet(
+        commandIndex: Int,
+        payload: ByteArray = byteArrayOf(),
+        xorKey: Int = 0, // 0 = no encryption
+    ): ByteArray {
+        require(commandIndex in 0..0xFF)
+        val encryptedPayload = if (xorKey != 0) xorEncrypt(payload, xorKey) else payload
+        val length = encryptedPayload.size
+        val frame = ByteArray(5 + encryptedPayload.size + 1).apply {
+            this[0] = SEND_HEADER.toByte()
+            this[1] = APP_CODE.toByte()
+            this[2] = commandIndex.toByte()
+            this[3] = ((length shr 8) and 0xFF).toByte()
+            this[4] = (length and 0xFF).toByte()
+            encryptedPayload.copyInto(this, destinationOffset = 5)
+        }
+        // Calculate CRC
+        var crc = 0
+        for (i in 0 until frame.size - 1) {
+            crc += frame[i].unsigned()
+        }
+        frame[frame.size - 1] = (crc and 0xFF).toByte()
+        return frame
+    }
+
+    fun xorEncrypt(data: ByteArray, key: Int): ByteArray {
+        val result = ByteArray(data.size)
+        for (i in data.indices) {
+            result[i] = ((data[i].unsigned() xor key) and 0xFF).toByte()
+        }
+        return result
+    }
+
+    // ── Decoder ──
+
+    class Decoder(initialCapacity: Int = 256) {
+        private var bytes = ByteArray(initialCapacity.coerceAtLeast(16))
+        private var size = 0
+
+        fun offer(chunk: ByteArray, xorKey: Int = 0): List<Frame> {
+            if (chunk.isEmpty()) return emptyList()
+            append(chunk)
+            val frames = mutableListOf<Frame>()
+            while (true) {
+                discardNoise()
+                if (size < 6) return frames // minimum: header(1) + appCode(1) + cmd(1) + len(2) + crc(1)
+
+                val header = peek(0)
+                if (header != RECEIVE_HEADER && header != RECEIVE_HEADER_OLD && header != SEND_HEADER) {
+                    discard(1)
+                    continue
+                }
+
+                val lengthField = (peek(3) shl 8) or peek(4)
+                val frameLength = 5 + lengthField + 1 // header + appCode + cmd + len(2) + payload + crc
+                if (size < frameLength) return frames
+
+                // Verify CRC
+                val candidate = peekBytes(frameLength)
+                var crcSum = 0
+                for (i in 0 until frameLength - 1) {
+                    crcSum += candidate[i].unsigned()
+                }
+                val expectedCrc = crcSum and 0xFF
+                val actualCrc = candidate[frameLength - 1].unsigned()
+                if (expectedCrc != actualCrc) {
+                    discard(1)
+                    continue
+                }
+
+                // Valid frame, consume it
+                discard(frameLength)
+                val rawPayload = candidate.copyOfRange(5, 5 + lengthField)
+                val decryptedPayload = if (xorKey != 0) xorEncrypt(rawPayload, xorKey) else rawPayload
+                frames += Frame(
+                    header = header,
+                    appCode = candidate[1].unsigned(),
+                    commandIndex = candidate[2].unsigned(),
+                    payload = decryptedPayload,
+                    bytes = candidate,
+                )
+            }
+        }
+
+        fun reset() {
+            size = 0
+        }
+
+        private fun append(chunk: ByteArray) {
+            ensureCapacity(size + chunk.size)
+            chunk.copyInto(bytes, destinationOffset = size)
+            size += chunk.size
+        }
+
+        private fun discardNoise() {
+            var count = 0
+            while (count < size) {
+                val b = peek(count)
+                if (b == RECEIVE_HEADER || b == RECEIVE_HEADER_OLD || b == SEND_HEADER) break
+                count++
+            }
+            if (count > 0) discard(count)
+        }
+
+        private fun peek(index: Int): Int = bytes[index].unsigned()
+        private fun peekBytes(count: Int): ByteArray = bytes.copyOfRange(0, count)
+
+        private fun discard(count: Int) {
+            if (count >= size) {
+                size = 0
+                return
+            }
+            bytes.copyInto(bytes, destinationOffset = 0, startIndex = count, endIndex = size)
+            size -= count
+        }
+
+        private fun ensureCapacity(required: Int) {
+            if (required <= bytes.size) return
+            var capacity = bytes.size
+            while (capacity < required) capacity *= 2
+            bytes = bytes.copyOf(capacity)
+        }
+    }
+
+    fun ByteArray.hex(): String =
+        joinToString(" ") { "%02X".format(it.unsigned()) }
+
+    private fun Byte.unsigned(): Int = toInt() and 0xFF
+}

--- a/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
+++ b/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
@@ -10,7 +10,7 @@ package dev.hyperears.protocol.edifier
  * - Receive: [0xBB][APP_CODE][CMD_INDEX][LEN_H][LEN_L][PAYLOAD...][CRC8]  (older: 0xCC)
  *
  * CRC: sum of all preceding bytes & 0xFF (verified: AA+EC+D8+00+00 = 0x26E -> &0xFF = 0x6E)
- * Payload is plaintext on SEND. ANC set payload is [ancIndex][ancValue].
+ * Payloads in both directions use XOR `0xA5`. ANC set plaintext is [ancIndex][ancValue].
  */
 object EdifierWireCodec {
     const val SEND_HEADER = 0xAA

--- a/protocol/src/test/java/dev/hyperears/protocol/edifier/EdifierWireCodecTest.kt
+++ b/protocol/src/test/java/dev/hyperears/protocol/edifier/EdifierWireCodecTest.kt
@@ -1,0 +1,114 @@
+package dev.hyperears.protocol.edifier
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EdifierWireCodecTest {
+
+    // ── Real captured frames from Edifier W860NB PRO (via protocol-test) ──
+
+    /** Battery response: BB EC D0 00 01 99 11 -> payload[0]=0x99 ^ 0xA5 = 0x3C = 60% */
+    @Test
+    fun `parse battery response 0x99 gives 60 percent`() {
+        val bytes = byteArrayOf(
+            0xBB.toByte(), 0xEC.toByte(), 0xD0.toByte(), 0x00.toByte(), 0x01.toByte(),
+            0x99.toByte(), 0x11.toByte(),
+        )
+        val frames = EdifierWireCodec.Decoder().offer(bytes)
+        assertEquals(1, frames.size)
+        val battery = EdifierWireCodec.parseBatteryState(frames[0])
+        assertNotNull(battery)
+        assertEquals(60, battery!!.wholeUnit)
+    }
+
+    /** ANC response for NC off: BB EC CC 00 02 B5 A0 CA -> payload B5 A0 -> 10 05 */
+    @Test
+    fun `parse ANC response B5 A0 gives ancIndex 16 ancValue 5`() {
+        val bytes = byteArrayOf(
+            0xBB.toByte(), 0xEC.toByte(), 0xCC.toByte(), 0x00.toByte(), 0x02.toByte(),
+            0xB5.toByte(), 0xA0.toByte(), 0xCA.toByte(),
+        )
+        val frames = EdifierWireCodec.Decoder().offer(bytes)
+        assertEquals(1, frames.size)
+        val anc = EdifierWireCodec.parseAncState(frames[0])
+        assertNotNull(anc)
+        assertEquals(0x10, anc!!.mode) // ancIndex 16
+        assertEquals(5, anc.level) // ancValue 5 = NC off
+    }
+
+    /** ANC response for comfort NC: BB EC CC 00 02 B5 A7 D1 -> 10 02 */
+    @Test
+    fun `parse ANC response B5 A7 gives ancValue 2 comfort`() {
+        val bytes = byteArrayOf(
+            0xBB.toByte(), 0xEC.toByte(), 0xCC.toByte(), 0x00.toByte(), 0x02.toByte(),
+            0xB5.toByte(), 0xA7.toByte(), 0xD1.toByte(),
+        )
+        val frames = EdifierWireCodec.Decoder().offer(bytes)
+        assertEquals(1, frames.size)
+        val anc = EdifierWireCodec.parseAncState(frames[0])
+        assertEquals(2, anc!!.level)
+    }
+
+    // ── Send framing ──
+
+    /** Battery query: AA EC D0 00 00 66 */
+    @Test
+    fun `battery query frame matches real capture`() {
+        val expected = byteArrayOf(
+            0xAA.toByte(), 0xEC.toByte(), 0xD0.toByte(), 0x00.toByte(), 0x00.toByte(), 0x66.toByte(),
+        )
+        val actual = EdifierWireCodec.queryBattery
+        assertEquals(expected.toHex(), actual.toHex())
+    }
+
+    /**
+     * ANC set (deep NC): payload 10 01 -> encrypted B5 A4. raw = AA EC C1 00 02 B5 A4 B2
+     */
+    @Test
+    fun `set ANC deep produces expected frame`() {
+        val expected = byteArrayOf(
+            0xAA.toByte(), 0xEC.toByte(), 0xC1.toByte(), 0x00.toByte(), 0x02.toByte(),
+            0xB5.toByte(), 0xA4.toByte(), 0xB2.toByte(),
+        )
+        val actual = EdifierWireCodec.setAnc(EdifierWireCodec.ANC_VALUE_DEEP)
+        assertEquals(expected.toHex(), actual.toHex())
+    }
+
+    /** ANC set (NC off): payload 10 05 -> encrypted B5 A0. raw = AA EC C1 00 02 B5 A0 AE */
+    @Test
+    fun `set ANC off produces expected frame`() {
+        val expected = byteArrayOf(
+            0xAA.toByte(), 0xEC.toByte(), 0xC1.toByte(), 0x00.toByte(), 0x02.toByte(),
+            0xB5.toByte(), 0xA0.toByte(), 0xAE.toByte(),
+        )
+        val actual = EdifierWireCodec.setAnc(EdifierWireCodec.ANC_VALUE_OFF)
+        assertEquals(expected.toHex(), actual.toHex())
+    }
+
+    @Test
+    fun `garbage input is discarded`() {
+        val bytes = byteArrayOf(
+            0x01, 0x02, 0x03, 0xAA.toByte(), 0xEC.toByte(), 0xD0.toByte(), 0x00.toByte(),
+            0x00.toByte(), 0x66.toByte(),
+        )
+        val frames = EdifierWireCodec.Decoder().offer(bytes)
+        assertEquals(1, frames.size)
+    }
+
+    @Test
+    fun `null battery on empty payload`() {
+        val frame = EdifierWireCodec.Frame(
+            header = EdifierWireCodec.RECEIVE_HEADER,
+            appCode = EdifierWireCodec.APP_CODE,
+            commandIndex = EdifierWireCodec.CMD_BATTERY_QUERY,
+            payload = byteArrayOf(),
+            bytes = byteArrayOf(),
+        )
+        assertNull(EdifierWireCodec.parseBatteryState(frame))
+    }
+
+    private fun ByteArray.toHex(): String =
+        joinToString(" ") { "%02X".format(it.toInt() and 0xFF) }
+}

--- a/system-module/build.gradle.kts
+++ b/system-module/build.gradle.kts
@@ -22,8 +22,8 @@ android {
         applicationId = "dev.hyperears"
         minSdk = 35
         targetSdk = 36
-        versionCode = 32
-        versionName = "0.10.4"
+        versionCode = 33
+        versionName = "0.11.0"
     }
 
     signingConfigs {

--- a/system-module/src/main/java/dev/hyperears/bridge/StateBroadcaster.kt
+++ b/system-module/src/main/java/dev/hyperears/bridge/StateBroadcaster.kt
@@ -12,7 +12,7 @@ object StateBroadcaster {
                     state = state,
                     sessionToken = sessionToken,
                     targetPackage = targetPackage,
-                ),
+                ).addFlags(Intent.FLAG_RECEIVER_FOREGROUND),
             )
         }
     }

--- a/system-module/src/main/java/dev/hyperears/hook/EdifierW860NBProMiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/EdifierW860NBProMiLinkCardAdapter.kt
@@ -94,7 +94,7 @@ internal object EdifierW860NBProMiLinkCardAdapter : MiLinkCardAdapter {
         private val wind = WeakReference(wind)
 
         override fun render(state: EarbudState) {
-            val mode = state.noiseMode ?: return
+            val mode = state.noiseMode
             val projected = projectNativeNoiseMode(mode)
             transparency.get()?.isSelected =
                 isModeSelected(NoiseMode.TRANSPARENCY, projected)
@@ -111,15 +111,7 @@ internal object EdifierW860NBProMiLinkCardAdapter : MiLinkCardAdapter {
 
         fun onWindClick() {
             val current = environment.stateProvider(address)
-            if (!current.sessionActive || !current.connected) {
-                return
-            }
-            // Toggle: wind → ANC, other → wind
-            val target = if (current.noiseMode == NoiseMode.WIND) {
-                NoiseMode.ANC
-            } else {
-                NoiseMode.WIND
-            }
+            val target = EdifierWindControlPolicy.request(current) ?: return
             environment.controlSender(address, target)
         }
 
@@ -145,4 +137,12 @@ internal object EdifierW860NBProMiLinkCardAdapter : MiLinkCardAdapter {
     private const val WIND_LABEL = "抗风噪"
     private const val ENABLED_ALPHA = 1.0f
     private const val DISABLED_ALPHA = 0.45f
+}
+
+/** Pure toggle policy for W860NB PRO's fourth native mode item. */
+internal object EdifierWindControlPolicy {
+    fun request(state: EarbudState): NoiseMode? {
+        if (!state.sessionActive || !state.connected) return null
+        return if (state.noiseMode == NoiseMode.WIND) NoiseMode.ANC else NoiseMode.WIND
+    }
 }

--- a/system-module/src/main/java/dev/hyperears/hook/EdifierW860NBProMiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/EdifierW860NBProMiLinkCardAdapter.kt
@@ -1,0 +1,148 @@
+package dev.hyperears.hook
+
+import android.view.View
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import dev.hyperears.integration.EarbudState
+import dev.hyperears.integration.EdifierW860NBProAdapter
+import dev.hyperears.integration.NoiseMode
+import java.lang.ref.WeakReference
+
+/**
+ * Adds Edifier W860NB PRO's wind-noise mode to MiLink's ANC card.
+ *
+ * The stock three-item row (ANC, transparency, off) is preserved. A fourth wind-noise item is
+ * added using MiLink's own [HOST_ANC_ITEM_CLASS] so the host retains layout, typography, icon
+ * sizing and selected-state animation. Comfort noise mode (ANC_VALUE_COMFORT) is projected onto
+ * the ANC button since MiLink has no native comfort-NC slot.
+ */
+internal object EdifierW860NBProMiLinkCardAdapter : MiLinkCardAdapter {
+    override val presentationId = EdifierW860NBProAdapter.PRESENTATION_ID
+
+    /** WIND is its own mode, not projected onto any native slot. */
+    override fun projectNativeNoiseMode(mode: NoiseMode?): NoiseMode? = mode
+
+    override fun bind(
+        root: View,
+        address: String,
+        environment: MiLinkCardEnvironment,
+    ): MiLinkCardBinding? {
+        val ancCard = root.findMiLinkView(ANC_CARD_ID) as? LinearLayout ?: return null
+        val transparency = root.findMiLinkView(ANC_TRANSPARENCY_ID) ?: return null
+        val noiseCancellation = root.findMiLinkView(ANC_NOISE_CANCELLATION_ID) ?: return null
+        val off = root.findMiLinkView(ANC_OFF_ID) ?: return null
+        if (
+            transparency.parent !== ancCard ||
+            noiseCancellation.parent !== ancCard ||
+            off.parent !== ancCard
+        ) {
+            return null
+        }
+
+        val wind = createNativeMiLinkAncItem(
+            context = root.context,
+            hostClassLoader = environment.hostClassLoader,
+            layoutTemplate = noiseCancellation,
+        ) ?: return null
+        val windTitle = wind.findMiLinkView(ANC_TITLE_ID) as? TextView ?: return null
+        val windIcon = wind.findMiLinkView(ANC_ICON_ID) as? ImageView ?: return null
+        val noiseIcon =
+            noiseCancellation.findMiLinkView(ANC_ICON_ID) as? ImageView ?: return null
+
+        windTitle.text = WIND_LABEL
+        windIcon.setImageDrawable(
+            noiseIcon.drawable?.constantState
+                ?.newDrawable(root.resources)
+                ?.mutate()
+                ?: noiseIcon.drawable,
+        )
+        wind.contentDescription = WIND_LABEL
+        wind.visibility = View.VISIBLE
+        wind.isSaveEnabled = false
+        wind.isClickable = true
+        wind.isFocusable = true
+        ancCard.addView(wind)
+
+        val binding = Binding(
+            parent = ancCard,
+            transparency = transparency,
+            noiseCancellation = noiseCancellation,
+            off = off,
+            wind = wind,
+            address = address,
+            environment = environment,
+        )
+        wind.setOnClickListener { binding.onWindClick() }
+        ModuleLog.debug("MiLinkUi", "bound Edifier W860NB PRO wind mode")
+        return binding
+    }
+
+    private class Binding(
+        parent: LinearLayout,
+        transparency: View,
+        noiseCancellation: View,
+        off: View,
+        wind: View,
+        private val address: String,
+        private val environment: MiLinkCardEnvironment,
+    ) : MiLinkCardBinding {
+        private val parent = WeakReference(parent)
+        private val transparency = WeakReference(transparency)
+        private val noiseCancellation = WeakReference(noiseCancellation)
+        private val off = WeakReference(off)
+        private val wind = WeakReference(wind)
+
+        override fun render(state: EarbudState) {
+            val mode = state.noiseMode ?: return
+            val projected = projectNativeNoiseMode(mode)
+            transparency.get()?.isSelected =
+                isModeSelected(NoiseMode.TRANSPARENCY, projected)
+            noiseCancellation.get()?.isSelected =
+                isModeSelected(NoiseMode.ANC, projected)
+            off.get()?.isSelected =
+                isModeSelected(NoiseMode.OFF, projected)
+            wind.get()?.apply {
+                isSelected = isModeSelected(NoiseMode.WIND, mode)
+                isEnabled = state.sessionActive && state.connected
+                alpha = if (isEnabled) ENABLED_ALPHA else DISABLED_ALPHA
+            }
+        }
+
+        fun onWindClick() {
+            val current = environment.stateProvider(address)
+            if (!current.sessionActive || !current.connected) {
+                return
+            }
+            // Toggle: wind → ANC, other → wind
+            val target = if (current.noiseMode == NoiseMode.WIND) {
+                NoiseMode.ANC
+            } else {
+                NoiseMode.WIND
+            }
+            environment.controlSender(address, target)
+        }
+
+        override fun unbind() {
+            val parent = parent.get() ?: return
+            val wind = wind.get() ?: return
+            wind.setOnClickListener(null)
+            if (wind.parent === parent) parent.removeView(wind)
+        }
+    }
+
+    private fun isModeSelected(
+        itemMode: NoiseMode,
+        currentMode: NoiseMode?,
+    ): Boolean = itemMode == currentMode
+
+    private const val ANC_CARD_ID = "anc_card"
+    private const val ANC_TRANSPARENCY_ID = "anc_clear"
+    private const val ANC_NOISE_CANCELLATION_ID = "anc_noise_cancel"
+    private const val ANC_OFF_ID = "anc_off"
+    private const val ANC_TITLE_ID = "anc_title"
+    private const val ANC_ICON_ID = "anc_icon"
+    private const val WIND_LABEL = "抗风噪"
+    private const val ENABLED_ALPHA = 1.0f
+    private const val DISABLED_ALPHA = 0.45f
+}

--- a/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
@@ -59,6 +59,7 @@ internal object MiLinkCardAdapterRegistry {
     private val adapters = listOf(
         StarRingUltraMiLinkCardAdapter,
         BoseQuietComfortMiLinkCardAdapter,
+        EdifierW860NBProMiLinkCardAdapter,
     )
     private val byId = adapters.associateBy(MiLinkCardAdapter::presentationId)
 

--- a/system-module/src/main/java/dev/hyperears/hook/MiLinkServiceHook.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/MiLinkServiceHook.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.Bundle
+import android.os.SystemClock
 import android.provider.Settings
 import android.view.View
 import dev.hyperears.bridge.BridgeStage
@@ -1055,7 +1056,13 @@ internal class MiLinkServiceHook : HookContext() {
         sendControl(request, address)
     }
 
+    /** Last ANC switch time per address, for [EarbudAdapter.ancSwitchCooldownMs]. */
+    private val lastAncCommandAt = Collections.synchronizedMap(mutableMapOf<String, Long>())
+
     private fun sendControl(request: ControlRequest, address: String) {
+        if (request is ControlRequest.SetNoiseMode && isAncSwitchCoolingDown(address)) {
+            return
+        }
         val snapshot = ProcessStateStore.find(address) ?: return
         if (!snapshot.sessionActive) return
         val token = ProcessStateStore.sessionToken(address) ?: return
@@ -1063,7 +1070,23 @@ internal class MiLinkServiceHook : HookContext() {
             ModuleContract.control(request, address, token)
                 .addFlags(Intent.FLAG_RECEIVER_FOREGROUND),
         )
+        if (request is ControlRequest.SetNoiseMode) {
+            lastAncCommandAt[address] = SystemClock.elapsedRealtime()
+        }
         ModuleLog.debug("MiLink", "forwarded ${request.javaClass.simpleName}")
+    }
+
+    private fun isAncSwitchCoolingDown(address: String): Boolean {
+        val cooldown = adapterForAddress(address)?.ancSwitchCooldownMs ?: 0L
+        if (cooldown <= 0L) return false
+        val last = lastAncCommandAt[address] ?: 0L
+        val elapsed = SystemClock.elapsedRealtime() - last
+        val cooling = elapsed < cooldown
+        ModuleLog.debug(
+            "MiLink",
+            "anc cmd cooldown addr=${maskBluetoothAddress(address)} cooldown=${cooldown}ms elapsed=${elapsed}ms cooling=$cooling",
+        )
+        return cooling
     }
 
     private fun normalizeAddress(address: String): String = address.uppercase()

--- a/system-module/src/main/java/dev/hyperears/hook/MiLinkServiceHook.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/MiLinkServiceHook.kt
@@ -25,6 +25,7 @@ import dev.hyperears.integration.NoiseMode
 import dev.hyperears.runtime.toEarbudIdentity
 import java.lang.reflect.Method
 import java.util.Collections
+import java.util.Locale
 import java.util.WeakHashMap
 import java.util.concurrent.CompletableFuture
 
@@ -50,6 +51,7 @@ internal class MiLinkServiceHook : HookContext() {
     private val observationLock = Any()
     private val sessionStages = mutableMapOf<String, SessionStages>()
     private val pendingStages = mutableMapOf<String, MutableSet<BridgeStage>>()
+    private val ancSwitchCooldownGate = AncSwitchCooldownGate()
 
     @Volatile
     private var context: Context? = null
@@ -1056,40 +1058,34 @@ internal class MiLinkServiceHook : HookContext() {
         sendControl(request, address)
     }
 
-    /** Last ANC switch time per address, for [EarbudAdapter.ancSwitchCooldownMs]. */
-    private val lastAncCommandAt = Collections.synchronizedMap(mutableMapOf<String, Long>())
-
     private fun sendControl(request: ControlRequest, address: String) {
-        if (request is ControlRequest.SetNoiseMode && isAncSwitchCoolingDown(address)) {
-            return
-        }
         val snapshot = ProcessStateStore.find(address) ?: return
         if (!snapshot.sessionActive) return
         val token = ProcessStateStore.sessionToken(address) ?: return
-        context?.sendBroadcast(
-            ModuleContract.control(request, address, token)
-                .addFlags(Intent.FLAG_RECEIVER_FOREGROUND),
-        )
+        val targetContext = context ?: return
+        val send = {
+            targetContext.sendBroadcast(
+                ModuleContract.control(request, address, token)
+                    .addFlags(Intent.FLAG_RECEIVER_FOREGROUND),
+            )
+        }
         if (request is ControlRequest.SetNoiseMode) {
-            lastAncCommandAt[address] = SystemClock.elapsedRealtime()
+            val cooldown = adapterForAddress(address)?.ancSwitchCooldownMs ?: 0L
+            if (!ancSwitchCooldownGate.runIfReady(address, cooldown, send)) {
+                ModuleLog.debug(
+                    "MiLink",
+                    "suppressed ANC command during ${cooldown}ms cooldown " +
+                        "address=${maskBluetoothAddress(address)}",
+                )
+                return
+            }
+        } else {
+            send()
         }
         ModuleLog.debug("MiLink", "forwarded ${request.javaClass.simpleName}")
     }
 
-    private fun isAncSwitchCoolingDown(address: String): Boolean {
-        val cooldown = adapterForAddress(address)?.ancSwitchCooldownMs ?: 0L
-        if (cooldown <= 0L) return false
-        val last = lastAncCommandAt[address] ?: 0L
-        val elapsed = SystemClock.elapsedRealtime() - last
-        val cooling = elapsed < cooldown
-        ModuleLog.debug(
-            "MiLink",
-            "anc cmd cooldown addr=${maskBluetoothAddress(address)} cooldown=${cooldown}ms elapsed=${elapsed}ms cooling=$cooling",
-        )
-        return cooling
-    }
-
-    private fun normalizeAddress(address: String): String = address.uppercase()
+    private fun normalizeAddress(address: String): String = address.uppercase(Locale.ROOT)
 
     private fun String.bridgeStage(): BridgeStage = when (this) {
         "checkIsMiTWS",
@@ -1112,5 +1108,33 @@ internal class MiLinkServiceHook : HookContext() {
         const val HEADSET_PROPERTY_CHANGED = 4
         val BLUETOOTH_ADDRESS_PATTERN =
             Regex("^(?:[0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$")
+    }
+}
+
+/** Per-device command gate used only by adapters that declare an ANC prompt window. */
+internal class AncSwitchCooldownGate(
+    private val clockMillis: () -> Long = SystemClock::elapsedRealtime,
+) {
+    private val lock = Any()
+    private val lastCommandAt = mutableMapOf<String, Long>()
+
+    fun runIfReady(
+        address: String,
+        cooldownMs: Long,
+        action: () -> Unit,
+    ): Boolean = synchronized(lock) {
+        if (cooldownMs <= 0L) {
+            action()
+            return@synchronized true
+        }
+        val key = address.uppercase(Locale.ROOT)
+        val now = clockMillis()
+        val last = lastCommandAt[key]
+        if (last != null && now - last < cooldownMs) {
+            return@synchronized false
+        }
+        action()
+        lastCommandAt[key] = clockMillis()
+        true
     }
 }

--- a/system-module/src/main/java/dev/hyperears/ui/about/AboutScreen.kt
+++ b/system-module/src/main/java/dev/hyperears/ui/about/AboutScreen.kt
@@ -51,6 +51,7 @@ private val verifiedDevices = listOf(
     SupportEntry("vivo TWS Air3 Pro", "左右耳及充电盒电量、三态降噪、设备流转"),
     SupportEntry("StarRing Ultra", "左右耳电量、三态噪声控制、抗风噪开关、设备流转"),
     SupportEntry("Bose QuietComfort Headphones", "整机电量、BMAP 模式切换、设备流转"),
+    SupportEntry("Edifier W860NB PRO", "整机电量、降噪及防风噪控制、设备流转"),
 )
 
 private val familyDevices = listOf(
@@ -61,6 +62,7 @@ private val familyDevices = listOf(
     ),
     SupportEntry("OPPO Enco", "Air2 Pro、Free4、X3、Air5 及其他 Enco 家族设备"),
     SupportEntry("Bose BMAP", "具体产品确认后启用对应能力"),
+    SupportEntry("其他 Edifier 头戴", "BES 家族协议推测性回退；不开放未验证控制"),
 )
 
 private val projectLinks = listOf(
@@ -196,7 +198,7 @@ fun AboutScreen(onBack: () -> Unit) {
                     }
 
                     Text(
-                        text = "© 2026 HyperEars contributors\nHyperEars 与 Xiaomi、vivo、iQOO、OPPO、Bose 及相关品牌无关。产品名称仅用于兼容性说明。",
+                        text = "© 2026 HyperEars contributors\nHyperEars 与 Xiaomi、vivo、iQOO、OPPO、Bose、Edifier 及相关品牌无关。产品名称仅用于兼容性说明。",
                         modifier = Modifier.padding(horizontal = 4.dp),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,

--- a/system-module/src/test/java/dev/hyperears/hook/AncSwitchCooldownGateTest.kt
+++ b/system-module/src/test/java/dev/hyperears/hook/AncSwitchCooldownGateTest.kt
@@ -1,0 +1,54 @@
+package dev.hyperears.hook
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AncSwitchCooldownGateTest {
+    @Test
+    fun cooldownIsIsolatedByNormalizedDeviceAddress() {
+        var now = 1_000L
+        var writes = 0
+        val gate = AncSwitchCooldownGate { now }
+
+        assertTrue(gate.runIfReady("aa:bb:cc:dd:ee:ff", 1_800L) { writes++ })
+        now = 2_799L
+        assertFalse(gate.runIfReady("AA:BB:CC:DD:EE:FF", 1_800L) { writes++ })
+        assertTrue(gate.runIfReady("11:22:33:44:55:66", 1_800L) { writes++ })
+        now = 2_800L
+        assertTrue(gate.runIfReady("AA:BB:CC:DD:EE:FF", 1_800L) { writes++ })
+
+        assertEquals(3, writes)
+    }
+
+    @Test
+    fun zeroCooldownNeverRetainsState() {
+        var writes = 0
+        val gate = AncSwitchCooldownGate { 1_000L }
+
+        repeat(3) {
+            assertTrue(gate.runIfReady("AA:BB:CC:DD:EE:FF", 0L) { writes++ })
+        }
+
+        assertEquals(3, writes)
+    }
+
+    @Test
+    fun failedActionDoesNotStartCooldown() {
+        var now = 1_000L
+        var writes = 0
+        val gate = AncSwitchCooldownGate { now }
+
+        assertThrows(IllegalStateException::class.java) {
+            gate.runIfReady("AA:BB:CC:DD:EE:FF", 1_800L) {
+                error("broadcast failed")
+            }
+        }
+        now = 1_001L
+        assertTrue(gate.runIfReady("AA:BB:CC:DD:EE:FF", 1_800L) { writes++ })
+
+        assertEquals(1, writes)
+    }
+}

--- a/system-module/src/test/java/dev/hyperears/hook/EdifierW860NBProMiLinkCardAdapterTest.kt
+++ b/system-module/src/test/java/dev/hyperears/hook/EdifierW860NBProMiLinkCardAdapterTest.kt
@@ -1,0 +1,50 @@
+package dev.hyperears.hook
+
+import dev.hyperears.integration.EarbudState
+import dev.hyperears.integration.NoiseMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EdifierW860NBProMiLinkCardAdapterTest {
+    private val connected = EarbudState(
+        sessionActive = true,
+        connected = true,
+    )
+
+    @Test
+    fun windItemTogglesBetweenWindAndDeepAnc() {
+        assertEquals(
+            NoiseMode.WIND,
+            EdifierWindControlPolicy.request(connected.copy(noiseMode = NoiseMode.ANC)),
+        )
+        assertEquals(
+            NoiseMode.ANC,
+            EdifierWindControlPolicy.request(connected.copy(noiseMode = NoiseMode.WIND)),
+        )
+    }
+
+    @Test
+    fun windItemCanBeEnteredFromEveryNativeMode() {
+        listOf(NoiseMode.TRANSPARENCY, NoiseMode.OFF, null).forEach { mode ->
+            assertEquals(
+                NoiseMode.WIND,
+                EdifierWindControlPolicy.request(connected.copy(noiseMode = mode)),
+            )
+        }
+    }
+
+    @Test
+    fun windItemRejectsRequestsWithoutALiveConnection() {
+        assertNull(
+            EdifierWindControlPolicy.request(
+                connected.copy(connected = false, noiseMode = NoiseMode.ANC),
+            ),
+        )
+        assertNull(
+            EdifierWindControlPolicy.request(
+                connected.copy(sessionActive = false, noiseMode = NoiseMode.WIND),
+            ),
+        )
+    }
+}

--- a/system-module/src/test/java/dev/hyperears/hook/MiLinkCardAdapterRegistryTest.kt
+++ b/system-module/src/test/java/dev/hyperears/hook/MiLinkCardAdapterRegistryTest.kt
@@ -1,6 +1,7 @@
 package dev.hyperears.hook
 
 import dev.hyperears.integration.BoseQuietComfortHeadphonesAdapter
+import dev.hyperears.integration.EdifierW860NBProAdapter
 import dev.hyperears.integration.MiLinkCardPresentationId
 import dev.hyperears.integration.NoiseMode
 import dev.hyperears.integration.StarRingUltraAdapter
@@ -28,6 +29,12 @@ class MiLinkCardAdapterRegistryTest {
             BoseQuietComfortMiLinkCardAdapter,
             MiLinkCardAdapterRegistry.resolve(
                 BoseQuietComfortHeadphonesAdapter.PRESENTATION_ID,
+            ),
+        )
+        assertSame(
+            EdifierW860NBProMiLinkCardAdapter,
+            MiLinkCardAdapterRegistry.resolve(
+                EdifierW860NBProAdapter.PRESENTATION_ID,
             ),
         )
         assertNull(


### PR DESCRIPTION
## 变更

- 合入 PR #12 的 Edifier W860NB PRO BES 协议、整机电量和噪声控制适配
- 增加型号专属 MiLink 四模式卡片及协议测试入口
- 补充精确判型、协议状态、卡片策略和按地址限流测试
- 收紧未验证 Edifier 家族能力说明，并同步关于页与免责声明
- 将应用版本提升至 0.11.0（versionCode 33）

## 验证

```text
./gradlew --no-daemon --no-build-cache clean testDebugUnitTest \
  :protocol-test:assembleDebug \
  :system-module:lintRelease \
  :system-module:assembleRelease
```

- 100 tests, 0 failures
- Release Lint: no issues
- protocol-test Debug APK built
- R8 Release APK built