### PR TITLE
fix(integration): 单耳独立连接时模式切换失效（连接后主动查询状态）

### DIFF
--- a/integration/src/main/java/dev/hyperears/integration/HonorX5sProAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/HonorX5sProAdapter.kt
@@ -74,7 +74,8 @@ private class HonorX5sProProtocolSession : ProtocolSession {
 
     private val supportedDepths = HonorAncDepth.entries.toSet()
 
-    override fun initialReadCommands(): List<ByteArray> = listOf(HonorX5sSppCodec.queryBattery)
+    override fun initialReadCommands(): List<ByteArray> =
+        HonorX5sSppCodec.initSequence + HonorX5sSppCodec.queryBattery
 
     override fun encode(request: ControlRequest): List<ByteArray> = when (request) {
         StandardControlRequest.Refresh -> listOf(HonorX5sSppCodec.queryBattery)

--- a/integration/src/test/java/dev/hyperears/integration/HonorX5sProAdapterTest.kt
+++ b/integration/src/test/java/dev/hyperears/integration/HonorX5sProAdapterTest.kt
@@ -253,6 +253,20 @@ class HonorX5sProAdapterTest {
     }
 
     @Test
+    fun initialCommandsIncludeStateQuery() {
+        // The state query (`2B 2A 01 00`) must be sent at connect so a single-eardrum
+        // connection gets a state report immediately instead of waiting for the pushed report.
+        val commands = adapter.beginHandshake().commands
+        assertTrue(
+            commands.any { cmd ->
+                val hexText = cmd.joinToString("") { it.toUByte().toString(16).padStart(2, '0') }
+                hexText.startsWith("5a0005002b2a0100")
+            },
+        )
+        assertTrue(commands.contains(HonorX5sSppCodec.queryBattery))
+    }
+
+    @Test
     fun refreshEncodesBatteryQuery() {
         val result = adapter.executeControl(StandardControlRequest.Refresh)
         assertTrue(result.accepted)

--- a/protocol/src/main/java/dev/hyperears/protocol/honor/HonorX5sSppCodec.kt
+++ b/protocol/src/main/java/dev/hyperears/protocol/honor/HonorX5sSppCodec.kt
@@ -51,6 +51,21 @@ object HonorX5sSppCodec {
     val queryBattery: ByteArray = hex("5A 00 09 00 01 08 01 00 02 00 03 00 FB B9")
 
     /**
+     * Captured vendor connect-init sequence (16:25 log, stable across captures). The vendor app
+     * sends these once after SPP establishes; the state query (`2B 2A 01 00`) is what makes the
+     * earphone reply with a state report immediately. Without it a single-eardrum connection
+     * may wait ~14s for the pushed report, leaving noise-mode capabilities unconfirmed.
+     */
+    val initSequence: List<ByteArray> = listOf(
+        hex("5A 00 23 00 01 07 01 00 02 00 03 00 04 00 05 00 06 00 07 00 08 00 09 00 0A 00 0B 00 0C 00 0F 00 11 00 19 00 22 00 A0 81"),
+        hex("5A 00 05 00 2B 68 01 00 31 B3"),
+        hex("5A 00 15 00 01 3A 01 10 02 0E 03 04 00 00 00 03 04 04 00 00 00 05 05 00 99 38"),
+        hex("5A 00 05 00 2B 2A 01 00 42 7E"),
+        hex("5A 00 06 00 01 02 01 01 2B 94 AB"),
+        hex("5A 00 0D 00 01 05 01 04 6A 75 96 62 02 02 08 00 1F 09"),
+    )
+
+    /**
      * Streaming frame splitter for the `5A 00` protocol.
      *
      * RFCOMM delivers a continuous byte stream: one read may carry a partial frame, several


### PR DESCRIPTION
# 单耳独立连接时模式切换失效修复

修复 X5s Pro 在**单耳独立连接**（另一耳不在手机连接范围）时模式切换无效的问题。

## 根因

单耳连接时耳机处于低频被动推送模式：模式状态帧（`2B 2A`）约 **14 秒**才主动推送一次（8/11 抓包确认：连接后 14 秒才收到第一条状态帧）。`PROTOCOL_HANDSHAKE` 与三态能力确认依赖状态帧 → 在状态帧到达前，`controlRequestContract` 校验拒绝所有模式切换（`noiseControl` 未确认）→ 表现为"切换失效"。

"先连双耳再断开一只"可用的原因：双耳连接时状态帧秒回、能力早已确认，断单耳后确认保留。

## 修复

连接建立后主动发送厂商 App 的初始化序列（16:25 抓包，多份日志稳定）：

- `01 07`（能力查询）
- `2B 68`
- `01 3A`（配置同步）
- **`2B 2A 01 00`（主动状态查询）** —— 关键：让耳机立即回状态帧，不再依赖 14 秒被动推送
- `01 02`、`01 05`
- `01 08`（电量查询，原有）

初始化后单耳连接**秒级确认三态能力**，模式切换立即可用；同时与厂商 App 的连接行为保持一致。

## 测试

- `initialCommandsIncludeStateQuery`：断言初始化序列包含状态查询与电量查询
- `:protocol:test`、`:integration:test`、`:system-module:test` 全绿（真实抓包字节断言）
- `assembleDebug` 构建通过

## 实机验证项

- 单耳独立连接（另一耳远离手机）→ 连接后数秒内切换降噪/透传/关闭应生效
