### PR TITLE
feat: add Ceramics X GATT support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ## [Unreleased]
 
+### ROSE Ceramics X
+
+- 根据实机 HCI Snoop 新增弱水时砂 ROSE Ceramics X（琉璃 X）伴生 BLE 适配。模块按
+  `CERAMICS X BLE` 精确关联控制端点，使用实测 ATT value handle `0x0015` 写入、`0x0017`
+  通知，以及厂商 `0x27` 查询、`0x2C` 设置、`0x28` 状态回报。
+- 协议确认后支持降噪 `0x01`、通透 `0x02`、抗风噪 `0x00` 和关闭 `0x03`；设置使用
+  Write Command，设备主动状态通知作为最终回读。未收到合法 `0x0C` 模式报告前不开放控制，
+  电量继续使用 Android 系统整机值，不推测抓包中尚未确认的私有电量字段。
+
 ## [2.3.2] - 2026-08-14
 
 本版修复 ROSE Ceramics Ultra（琉璃 Ultra）的模式识别与组件电量，并为未知 MiLink

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -122,15 +122,22 @@ StarRing Ultra 使用 GATT `7777/8888` 特征，厂商 RFCOMM 为回退通道。
 | ROSESELSA EARFREE i5 | 具体型号 | 公开实现 | 规范化名称精确匹配；合法电量与模式响应分别确认对应能力 | 系统整机 → 私有组件 | 降噪、关闭、通透、抗风噪 |
 | ROSESELSA EARFREE / EARFEEL 产品线 | 产品线 | 家族外推 | 产品线名称或 GATT 服务选择候选；合法状态响应确认能力 | 系统整机 → 私有组件 | 降噪、关闭、通透、抗风噪 |
 | Furina Endless Solo of Solitude | 具体型号 | 实机验证 | 规范化名称选择候选；BudsFeel 合法电量与模式响应分别确认对应能力 | 系统整机 → 私有组件 | 降噪、关闭、通透、抗风噪 |
+| ROSE Ceramics X（琉璃 X） | 具体型号 | 实机验证 | 规范化名称精确匹配 Classic 音频端点；精确名称关联 `CERAMICS X BLE` 控制端点；合法 `0x27/0x28` 模式响应确认能力 | 系统整机 | 降噪、关闭、通透、抗风噪 |
 | ROSE Ceramics Ultra（琉璃 Ultra） | 具体型号 | 实机验证 | 规范化名称选择候选；BudsFeel 扩展流中的合法电量与模式记录分别确认对应能力 | 系统整机 → 私有组件 | 降噪、关闭、通透、抗风噪 |
 | ROSE BudsFeel MK2 | 具体型号 | 公开实现 | 规范化名称精确匹配；合法电量与模式响应分别确认对应能力 | 系统整机 → 私有组件 | 降噪、关闭、通透、抗风噪 |
 | ROSE BudsFeel 产品线 | 产品线 | 家族外推 | 产品线名称或 RFCOMM 服务选择候选；合法状态响应确认能力 | 系统整机 → 私有组件 | 降噪、关闭、通透、抗风噪 |
 | 其他 ROSESELSA / ROSE 耳机 | 标准回退 | 标准回退 | 品牌名称与 Android 标准耳机身份匹配 | 系统整机 | 无 |
 
 EARFREE / EARFEEL 使用 GATT 服务 `011bf5da`、`7777/8888` 特征；BudsFeel 使用 RFCOMM
-UUID `0cf12d31-…`。Furina Endless Solo of Solitude 复用 BudsFeel 帧格式，实机确认可独立
-上报左耳、右耳和充电盒电量。ROSE Ceramics Ultra（琉璃 Ultra）由 RoseLink 官方 App
-经同一 `0cf12d31` RFCOMM 通道控制，实机确认复用 BudsFeel 帧格式；其状态响应在首个
+UUID `0cf12d31-…`。琉璃 X 使用与 Classic 音频地址分离的 `CERAMICS X BLE` 伴生端点；
+实机 HCI Snoop 确认 ATT value handle `0x0015` 以 Write Command 写入、`0x0017` 接收通知。
+厂商 value 使用 `0x27` 查询、`0x2C` 设置和 `0x28` 状态回报，模式值分别为抗风噪
+`0x00`、降噪 `0x01`、通透 `0x02`、关闭 `0x03`。初始仅保留系统整机电量；收到合法
+`00 27/28 02 00 03 0C 01 <mode>` 报告后才开放四态控制，设置后的 `0x28` 主动通知作为
+最终状态回读。抓包尚未确认私有电量字段，因此不发布组件电量。Furina Endless Solo of
+Solitude 复用 BudsFeel 帧格式，实机确认可独立上报左耳、右耳和充电盒电量。ROSE Ceramics
+Ultra（琉璃 Ultra）由 RoseLink 官方 App 经同一 `0cf12d31` RFCOMM 通道控制，实机确认复用
+BudsFeel 帧格式；其状态响应在首个
 块之后追加无长度头的扩展 TLV 流（噪声 `09`、电量 `0C` 记录位于扩展流内），
 解码器按扩展帧路径解析。该型号还会上报自适应降噪 `0x05` 与极致降噪 `0x06`，两者统一
 投影为系统卡片的“降噪”状态；组件电量百分比位于低七位，尚未确认语义的高位不会被投影为

--- a/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
@@ -600,6 +600,7 @@ object EarbudAdapterRegistry {
         add(Registration(edifierGroup, ::EdifierHeadphonesAdapter))
         add(Registration(edifierGroup, ::EdifierEarbudAdapter))
         add(Registration(roseGroup, ::FurinaEndlessAdapter))
+        add(Registration(roseGroup, ::RoseLuliXAdapter))
         add(Registration(roseGroup, ::RoseLuliUltraAdapter))
         add(Registration(roseGroup, ::RoseEarfreeI5Adapter))
         add(Registration(roseGroup, ::RoseEarfreeProtocolFamilyAdapter))

--- a/integration/src/main/java/dev/hyperears/integration/EarbudModel.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EarbudModel.kt
@@ -404,17 +404,22 @@ data class GattPeerIdentity(
 /** Adapter-owned association rule between one audio device and a companion BLE endpoint. */
 fun interface GattPeerMatcher {
     fun matches(sessionDevice: GattPeerIdentity, candidate: GattPeerIdentity): Boolean
+
+    /** Optional diagnostic label for a candidate accepted or considered by an adapter matcher. */
+    fun matchReason(sessionDevice: GattPeerIdentity, candidate: GattPeerIdentity): String? = null
 }
 
 /** Declarative BLE scan filter used only while resolving a companion control endpoint. */
 data class GattScanFilterSpec(
     val manufacturerId: Int? = null,
     val serviceUuid: String? = null,
+    val deviceName: String? = null,
 ) {
     init {
         require(manufacturerId == null || manufacturerId in 0..0xFFFF)
         require(serviceUuid == null || serviceUuid.isNotBlank())
-        require(manufacturerId != null || serviceUuid != null) {
+        require(deviceName == null || deviceName.isNotBlank())
+        require(manufacturerId != null || serviceUuid != null || deviceName != null) {
             "A companion GATT scan requires at least one stable filter"
         }
     }
@@ -447,24 +452,39 @@ sealed interface GattPeerSelection {
     }
 }
 
+enum class GattWriteMode {
+    WITH_RESPONSE,
+    WITHOUT_RESPONSE,
+}
+
 /**
  * BLE GATT transport whose characteristics carry the protocol's unmodified business frames.
  *
- * UUIDs are authoritative. Optional instance IDs pin a captured attribute table when a device
- * exposes duplicate characteristic UUIDs; runtimes still validate characteristic properties.
+ * UUIDs are authoritative when known. Instance IDs can pin a captured attribute table when a
+ * vendor omits characteristic discovery metadata; at least one identity must be present for each
+ * characteristic, and runtimes still validate characteristic properties.
  */
 data class GattTransportSpec(
     /** Optional service boundary used to disambiguate otherwise common characteristic UUIDs. */
     val serviceUuid: String? = null,
-    val writeCharacteristicUuid: String,
-    val notifyCharacteristicUuid: String,
+    val writeCharacteristicUuid: String? = null,
+    val notifyCharacteristicUuid: String? = null,
     val writeInstanceId: Int? = null,
     val notifyInstanceId: Int? = null,
+    val writeMode: GattWriteMode = GattWriteMode.WITH_RESPONSE,
     val peerSelection: GattPeerSelection = GattPeerSelection.SessionDevice,
     override val id: String,
 ) : EarbudTransportSpec {
     init {
         require(serviceUuid == null || serviceUuid.isNotBlank())
+        require(writeCharacteristicUuid?.isNotBlank() != false)
+        require(notifyCharacteristicUuid?.isNotBlank() != false)
+        require(writeCharacteristicUuid != null || writeInstanceId != null) {
+            "A GATT write characteristic requires a UUID or instance ID"
+        }
+        require(notifyCharacteristicUuid != null || notifyInstanceId != null) {
+            "A GATT notify characteristic requires a UUID or instance ID"
+        }
     }
 }
 

--- a/integration/src/main/java/dev/hyperears/integration/RoseEarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/RoseEarbudAdapter.kt
@@ -1,6 +1,7 @@
 package dev.hyperears.integration
 
 import dev.hyperears.protocol.rose.RoseBudsFeelMk2WireCodec
+import dev.hyperears.protocol.rose.RoseCeramicsXWireCodec
 import dev.hyperears.protocol.rose.RoseEarfreeI5WireCodec
 
 /** Standard Bluetooth fallback for ROSESELSA/ROSE headsets outside a known protocol family. */
@@ -114,6 +115,90 @@ class FurinaEndlessAdapter : RoseBudsFeelProtocolFamilyAdapter() {
         const val ID = "furina-endless-budsfeel"
         private val MODEL_NAMES = setOf("furinaendlesssoloofsolitude")
     }
+}
+
+class RoseLuliXAdapter : RoseEarbudAdapter() {
+    override val id: String = ID
+    override val displayName: String = "ROSE Ceramics X (Luli X)"
+    override val resolution: AdapterResolution = AdapterResolution.EXACT_MATCH
+    override val miLinkCardPresentationId: MiLinkCardPresentationId?
+        get() = PRESENTATION_ID.takeIf { effectiveCapabilities().noiseControl }
+    override val privateProtocolRequired: Boolean = true
+    override val transportReadiness: TransportReadiness = TransportReadiness.PROTOCOL_HANDSHAKE
+    override val batterySource: BatterySource = BatterySource.SYSTEM_AGGREGATE
+    override val capabilities: EarbudCapabilities = EarbudCapabilities(
+        battery = true,
+        audioHandoff = true,
+    )
+    override val transports: List<EarbudTransportSpec> = listOf(
+        GattTransportSpec(
+            serviceUuid = SERVICE_UUID,
+            writeCharacteristicUuid = WRITE_CHARACTERISTIC_UUID,
+            notifyCharacteristicUuid = NOTIFY_CHARACTERISTIC_UUID,
+            writeInstanceId = WRITE_ATTRIBUTE_HANDLE,
+            notifyInstanceId = NOTIFY_ATTRIBUTE_HANDLE,
+            writeMode = GattWriteMode.WITHOUT_RESPONSE,
+            peerSelection = GattPeerSelection.CompanionDevice(
+                filter = GattScanFilterSpec(deviceName = COMPANION_DEVICE_NAME),
+                matcher = RoseLuliXGattPeerMatcher,
+                scanTimeoutMs = 20_000L,
+            ),
+            id = "rose-luli-x-companion-gatt",
+        ),
+    )
+
+    override fun matches(identity: EarbudIdentity): Boolean {
+        if (identity.nativeSystemEarbud) return false
+        return normalizeDeviceName(identity.deviceName.orEmpty()) in MODEL_NAMES
+    }
+
+    override fun createProtocolSession(): ProtocolSession = RoseLuliXProtocolSession()
+
+    override fun onInitialProtocolUnavailable(): InitialProtocolFailureResolution =
+        InitialProtocolFailureResolution.KeepDormant
+
+    companion object {
+        const val ID = "rose-luli-x-gatt"
+        val PRESENTATION_ID = MiLinkCardPresentationId("rose-luli-x-gatt")
+        const val COMPANION_DEVICE_NAME = "CERAMICS X BLE"
+        const val COMPANION_MANUFACTURER_ID = 0x8418
+        const val SERVICE_UUID =
+            "0000fdb3-0000-1000-8000-00805f9b34fb"
+        const val WRITE_ATTRIBUTE_HANDLE = 0x0015
+        const val NOTIFY_ATTRIBUTE_HANDLE = 0x0017
+        const val WRITE_CHARACTERISTIC_UUID =
+            "0000ff16-0000-1000-8000-00805f9b34fb"
+        const val NOTIFY_CHARACTERISTIC_UUID =
+            "0000ff17-0000-1000-8000-00805f9b34fb"
+        private val MODEL_NAMES = setOf(
+            "roseceramicsx",
+            "roselulix",
+        )
+    }
+}
+
+internal object RoseLuliXGattPeerMatcher : GattPeerMatcher {
+    override fun matches(sessionDevice: GattPeerIdentity, candidate: GattPeerIdentity): Boolean =
+        matchReason(sessionDevice, candidate) != null
+
+    override fun matchReason(
+        sessionDevice: GattPeerIdentity,
+        candidate: GattPeerIdentity,
+    ): String? {
+        val sessionName = normalize(sessionDevice.deviceName)
+        if (sessionName !in setOf("roseceramicsx", "roselulix")) return null
+
+        val candidateName = normalize(candidate.deviceName)
+        return when {
+            candidateName == normalize(RoseLuliXAdapter.COMPANION_DEVICE_NAME) -> "device-name"
+            candidate.manufacturerData.containsKey(RoseLuliXAdapter.COMPANION_MANUFACTURER_ID) ->
+                "manufacturer-id"
+            else -> null
+        }
+    }
+
+    private fun normalize(value: String?): String =
+        value.orEmpty().lowercase().filter(Char::isLetterOrDigit)
 }
 
 /**
@@ -240,6 +325,58 @@ class RoseBudsFeelMk2Adapter : RoseBudsFeelProtocolFamilyAdapter() {
         const val ID = "rose-budsfeel-mk2"
         val PRESENTATION_ID = RoseBudsFeelProtocolFamilyAdapter.PRESENTATION_ID
         private val MODEL_NAMES = setOf("rosebudsfeelmk2", "budsfeelmk2")
+    }
+}
+
+private class RoseLuliXProtocolSession : ProtocolSession {
+    private var handshakePublished = false
+
+    override fun initialReadCommands(): List<ByteArray> =
+        listOf(RoseCeramicsXWireCodec.queryNoiseMode)
+
+    override fun encode(request: ControlRequest): List<ByteArray> = when {
+        request === StandardControlRequest.Refresh -> initialReadCommands()
+        request is StandardControlRequest.SetNoiseMode -> listOf(
+            RoseCeramicsXWireCodec.setNoiseMode(request.mode.toLuliXMode()),
+        )
+        else -> emptyList()
+    }
+
+    override fun readback(request: ControlRequest): List<ByteArray> = emptyList()
+
+    override fun offer(bytes: ByteArray): List<ProtocolEvent> {
+        val mode = RoseCeramicsXWireCodec.parseNoiseMode(bytes) ?: return emptyList()
+        return buildList {
+            if (!handshakePublished) {
+                add(ProtocolEvent.HandshakeAccepted)
+                handshakePublished = true
+            }
+            add(
+                ProtocolEvent.CapabilitiesIdentified(
+                    battery = false,
+                    noiseModes = NoiseMode.entries.toSet(),
+                ),
+            )
+            add(ProtocolEvent.FeatureStateChanged(NoiseModeFeatureState(mode.toDomainMode())))
+        }
+    }
+
+    override fun reset() {
+        handshakePublished = false
+    }
+
+    private fun NoiseMode.toLuliXMode(): RoseCeramicsXWireCodec.NoiseMode = when (this) {
+        NoiseMode.ANC -> RoseCeramicsXWireCodec.NoiseMode.ANC
+        NoiseMode.OFF -> RoseCeramicsXWireCodec.NoiseMode.OFF
+        NoiseMode.TRANSPARENCY -> RoseCeramicsXWireCodec.NoiseMode.TRANSPARENCY
+        NoiseMode.WIND -> RoseCeramicsXWireCodec.NoiseMode.WIND
+    }
+
+    private fun RoseCeramicsXWireCodec.NoiseMode.toDomainMode(): NoiseMode = when (this) {
+        RoseCeramicsXWireCodec.NoiseMode.ANC -> NoiseMode.ANC
+        RoseCeramicsXWireCodec.NoiseMode.OFF -> NoiseMode.OFF
+        RoseCeramicsXWireCodec.NoiseMode.TRANSPARENCY -> NoiseMode.TRANSPARENCY
+        RoseCeramicsXWireCodec.NoiseMode.WIND -> NoiseMode.WIND
     }
 }
 

--- a/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
+++ b/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
@@ -458,6 +458,120 @@ class EarbudAdapterHierarchyTest {
     }
 
     @Test
+    fun roseCeramicsXNameSelectsCapturedCompanionGattAdapter() {
+        val adapter = requireNotNull(
+            EarbudAdapterRegistry.resolve(
+                EarbudIdentity(
+                    deviceName = "ROSE Ceramics X",
+                    standardHeadset = true,
+                    serviceUuids = emptySet(),
+                ),
+            ),
+        )
+
+        assertTrue(adapter is RoseLuliXAdapter)
+        assertEquals(AdapterResolution.EXACT_MATCH, adapter.resolution)
+        assertTrue(adapter.privateProtocolRequired)
+        assertFalse(adapter.snapshot().capabilities.noiseControl)
+        assertTrue(adapter.snapshot().supportedNoiseModes.isEmpty())
+        assertEquals(BatterySource.SYSTEM_AGGREGATE, adapter.snapshot().batterySource)
+        val transport = adapter.transports.single() as GattTransportSpec
+        assertEquals(RoseLuliXAdapter.SERVICE_UUID, transport.serviceUuid)
+        assertEquals(
+            RoseLuliXAdapter.WRITE_CHARACTERISTIC_UUID,
+            transport.writeCharacteristicUuid,
+        )
+        assertEquals(
+            RoseLuliXAdapter.NOTIFY_CHARACTERISTIC_UUID,
+            transport.notifyCharacteristicUuid,
+        )
+        assertEquals(RoseLuliXAdapter.WRITE_ATTRIBUTE_HANDLE, transport.writeInstanceId)
+        assertEquals(RoseLuliXAdapter.NOTIFY_ATTRIBUTE_HANDLE, transport.notifyInstanceId)
+        assertEquals(GattWriteMode.WITHOUT_RESPONSE, transport.writeMode)
+        val selection = transport.peerSelection as GattPeerSelection.CompanionDevice
+        assertEquals(RoseLuliXAdapter.COMPANION_DEVICE_NAME, selection.filter.deviceName)
+        assertEquals(
+            InitialProtocolFailureResolution.KeepDormant,
+            adapter.onInitialProtocolUnavailable(),
+        )
+    }
+
+    @Test
+    fun roseLuliXAliasSelectsExactAdapter() {
+        assertTrue(resolve("ROSE Luli X", standard = true) is RoseLuliXAdapter)
+    }
+
+    @Test
+    fun roseLuliXCompanionMatcherAcceptsObservedNamelessManufacturer() {
+        val session = GattPeerIdentity("ROSE Ceramics X", "00:11:22:33:44:55")
+
+        assertTrue(
+            RoseLuliXGattPeerMatcher.matches(
+                session,
+                GattPeerIdentity(
+                    deviceName = null,
+                    deviceAddress = "66:77:88:99:AA:BB",
+                    manufacturerData = mapOf(
+                        RoseLuliXAdapter.COMPANION_MANUFACTURER_ID to byteArrayOf(0x01),
+                    ),
+                ),
+            ),
+        )
+        assertEquals(
+            "manufacturer-id",
+            RoseLuliXGattPeerMatcher.matchReason(
+                session,
+                GattPeerIdentity(
+                    deviceName = null,
+                    deviceAddress = "66:77:88:99:AA:BB",
+                    manufacturerData = mapOf(
+                        RoseLuliXAdapter.COMPANION_MANUFACTURER_ID to byteArrayOf(0x01),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun roseLuliXCompanionMatcherRejectsUnrelatedBlePeers() {
+        val session = GattPeerIdentity("ROSE Ceramics X", "00:11:22:33:44:55")
+        assertTrue(
+            RoseLuliXGattPeerMatcher.matches(
+                session,
+                GattPeerIdentity("CERAMICS X BLE", "66:77:88:99:AA:BB"),
+            ),
+        )
+        assertFalse(
+            RoseLuliXGattPeerMatcher.matches(
+                session,
+                GattPeerIdentity("Other BLE", "66:77:88:99:AA:BB"),
+            ),
+        )
+    }
+
+    @Test
+    fun roseLuliXEnablesAncControlOnlyAfterCapturedModeReport() {
+        val adapter = RoseLuliXAdapter()
+
+        assertFalse(adapter.executeControl(StandardControlRequest.SetNoiseMode(NoiseMode.ANC)).accepted)
+        assertEquals(
+            HandshakeResult.Ready,
+            adapter.receive(hex("00 27 02 00 03 0C 01 03")).handshake,
+        )
+        assertEquals(NoiseMode.OFF, adapter.runtimeState().noiseMode)
+
+        val result = adapter.executeControl(StandardControlRequest.SetNoiseMode(NoiseMode.ANC))
+
+        assertTrue(result.accepted)
+        assertEquals(
+            listOf(0x00, 0x2C, 0x01, 0x00, 0x01, 0x01),
+            result.commands.single().map { it.toInt() and 0xFF },
+        )
+        adapter.receive(hex("00 28 02 00 03 0C 01 01"))
+        assertEquals(NoiseMode.ANC, adapter.runtimeState().noiseMode)
+    }
+
+    @Test
     fun roseCeramicsNameSelectsLuliUltraBudsFeelAdapterWithoutCachedUuid() {
         val adapter = requireNotNull(
             EarbudAdapterRegistry.resolve(

--- a/protocol-test/src/main/java/dev/hyperears/protocoltest/ProtocolTestViewModel.kt
+++ b/protocol-test/src/main/java/dev/hyperears/protocoltest/ProtocolTestViewModel.kt
@@ -121,6 +121,7 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
     private val boseDecoder = BoseBmapWireCodec.Decoder()
     private val edifierDecoder = EdifierWireCodec.Decoder()
     private val roseBudsFeelDecoder = RoseBudsFeelMk2WireCodec.Decoder()
+    private var roseBudsFeelSequence = 2
     private val mutableState = MutableStateFlow(ProtocolUiState())
     val state: StateFlow<ProtocolUiState> = mutableState.asStateFlow()
     private val logId = AtomicLong()
@@ -335,6 +336,8 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
         connectionJob?.cancel()
         connectionJob = null
         activeTransport = ActiveTransport.NONE
+        roseBudsFeelDecoder.reset()
+        roseBudsFeelSequence = 2
         client.close()
         starRingGattClient.close()
         mutableState.value = mutableState.value.copy(
@@ -487,6 +490,31 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
             )
             markTimeoutsLater()
         }
+    }
+
+    fun setRoseBudsFeelNoiseMode(mode: RoseBudsFeelMk2WireCodec.NoiseMode) {
+        viewModelScope.launch {
+            if (!ensureConnected()) return@launch
+            if (mutableState.value.selectedTarget != ProtocolTarget.ROSE_BUDSFEEL) return@launch
+            mutableState.value = mutableState.value.copy(noiseApiStatus = "等待设置确认")
+            send(
+                RoseBudsFeelMk2WireCodec.setNoiseMode(nextRoseBudsFeelSequence(), mode),
+                "BudsFeel 设置${mode.label()}",
+            )
+            markTimeoutsLater()
+        }
+    }
+
+    private fun nextRoseBudsFeelSequence(): Int =
+        roseBudsFeelSequence.also { roseBudsFeelSequence = (roseBudsFeelSequence + 1) and 0xFF }
+
+    private fun RoseBudsFeelMk2WireCodec.NoiseMode.label(): String = when (this) {
+        RoseBudsFeelMk2WireCodec.NoiseMode.ANC -> "降噪"
+        RoseBudsFeelMk2WireCodec.NoiseMode.OFF -> "关闭"
+        RoseBudsFeelMk2WireCodec.NoiseMode.TRANSPARENCY -> "通透"
+        RoseBudsFeelMk2WireCodec.NoiseMode.WIND -> "抗风噪"
+        RoseBudsFeelMk2WireCodec.NoiseMode.ADAPTIVE_ANC -> "自适应降噪"
+        RoseBudsFeelMk2WireCodec.NoiseMode.EXTREME_ANC -> "极致降噪"
     }
 
     fun sendRaw() {

--- a/protocol/src/main/java/dev/hyperears/protocol/rose/RoseCeramicsXWireCodec.kt
+++ b/protocol/src/main/java/dev/hyperears/protocol/rose/RoseCeramicsXWireCodec.kt
@@ -1,0 +1,33 @@
+package dev.hyperears.protocol.rose
+
+/** Vendor value codec captured from the ROSE Ceramics X companion BLE endpoint. */
+object RoseCeramicsXWireCodec {
+    enum class NoiseMode(val value: Int) {
+        WIND(0x00),
+        ANC(0x01),
+        TRANSPARENCY(0x02),
+        OFF(0x03),
+    }
+
+    val queryNoiseMode: ByteArray
+        get() = byteArrayOf(0x00, 0x27, 0x01, 0x00, 0x01, NOISE_FIELD)
+
+    fun setNoiseMode(mode: NoiseMode): ByteArray =
+        byteArrayOf(0x00, 0x2C, 0x01, 0x00, 0x01, mode.value.toByte())
+
+    /** Accepts both the direct query response (`0x27`) and asynchronous state report (`0x28`). */
+    fun parseNoiseMode(value: ByteArray): NoiseMode? {
+        if (value.size != NOISE_REPORT_SIZE) return null
+        if (value[0].unsigned() != 0x00) return null
+        if (value[1].unsigned() !in setOf(0x27, 0x28)) return null
+        if (value[2].unsigned() != 0x02 || value[3].unsigned() != 0x00) return null
+        if (value[4].unsigned() != 0x03 || value[5].unsigned() != NOISE_FIELD.unsigned()) return null
+        if (value[6].unsigned() != 0x01) return null
+        return NoiseMode.entries.firstOrNull { it.value == value[7].unsigned() }
+    }
+
+    private fun Byte.unsigned(): Int = toInt() and 0xFF
+
+    private const val NOISE_REPORT_SIZE = 8
+    private const val NOISE_FIELD: Byte = 0x0C
+}

--- a/protocol/src/test/java/dev/hyperears/protocol/rose/RoseWireCodecsTest.kt
+++ b/protocol/src/test/java/dev/hyperears/protocol/rose/RoseWireCodecsTest.kt
@@ -5,6 +5,43 @@ import org.junit.Test
 
 class RoseWireCodecsTest {
     @Test
+    fun ceramicsXBuildsCapturedModeCommandsAndParsesQueryAndAsyncReports() {
+        assertEquals("00 27 01 00 01 0C", RoseCeramicsXWireCodec.queryNoiseMode.hex())
+        assertEquals(
+            "00 2C 01 00 01 01",
+            RoseCeramicsXWireCodec.setNoiseMode(RoseCeramicsXWireCodec.NoiseMode.ANC).hex(),
+        )
+        assertEquals(
+            "00 2C 01 00 01 02",
+            RoseCeramicsXWireCodec.setNoiseMode(RoseCeramicsXWireCodec.NoiseMode.TRANSPARENCY).hex(),
+        )
+        assertEquals(
+            "00 2C 01 00 01 00",
+            RoseCeramicsXWireCodec.setNoiseMode(RoseCeramicsXWireCodec.NoiseMode.WIND).hex(),
+        )
+        assertEquals(
+            "00 2C 01 00 01 03",
+            RoseCeramicsXWireCodec.setNoiseMode(RoseCeramicsXWireCodec.NoiseMode.OFF).hex(),
+        )
+        assertEquals(
+            RoseCeramicsXWireCodec.NoiseMode.OFF,
+            RoseCeramicsXWireCodec.parseNoiseMode(hex("00 27 02 00 03 0C 01 03")),
+        )
+        assertEquals(
+            RoseCeramicsXWireCodec.NoiseMode.ANC,
+            RoseCeramicsXWireCodec.parseNoiseMode(hex("00 28 02 00 03 0C 01 01")),
+        )
+    }
+
+    @Test
+    fun ceramicsXRejectsAckAndMalformedOrUnknownModeReports() {
+        assertEquals(null, RoseCeramicsXWireCodec.parseNoiseMode(hex("00 2C 02 00 01 00")))
+        assertEquals(null, RoseCeramicsXWireCodec.parseNoiseMode(hex("00 28 02 00 03 0C 01")))
+        assertEquals(null, RoseCeramicsXWireCodec.parseNoiseMode(hex("00 28 02 00 03 0C 01 04")))
+        assertEquals(null, RoseCeramicsXWireCodec.parseNoiseMode(hex("00 28 02 00 03 0D 01 01")))
+    }
+
+    @Test
     fun earfreeI5DecodesFragmentedBatteryAndNoiseFrames() {
         val battery = response(
             group = 0x01,

--- a/system-module/src/main/java/dev/hyperears/hook/EdifierFourModeMiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/EdifierFourModeMiLinkCardAdapter.kt
@@ -13,7 +13,7 @@ import dev.hyperears.integration.StandardControlRequest
 import java.lang.ref.WeakReference
 
 /**
- * Presents every protocol-confirmed four-mode Edifier dialect through MiLink's native ANC row.
+ * Presents a protocol-confirmed four-mode headset through MiLink's native ANC row.
  *
  * MiLink transports WIND through its ANC branch, so leaving the visible stock ANC item attached
  * would select ANC and WIND at the same time. Following the native-slot pattern used by the other

--- a/system-module/src/main/java/dev/hyperears/hook/ExtendedWindNoiseMiLinkCardAdapters.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/ExtendedWindNoiseMiLinkCardAdapters.kt
@@ -3,8 +3,14 @@ package dev.hyperears.hook
 import dev.hyperears.integration.NiceHckYuanDaoOrigAdapter
 import dev.hyperears.integration.RoseBudsFeelMk2Adapter
 import dev.hyperears.integration.RoseEarfreeI5Adapter
+import dev.hyperears.integration.RoseLuliXAdapter
 
 /** Model-owned registrations reusing the same native MiLink wind-noise accessory contract. */
+internal object RoseLuliXMiLinkCardAdapter : WindNoiseToggleMiLinkCardAdapter(
+    presentationId = RoseLuliXAdapter.PRESENTATION_ID,
+    modelLabel = "ROSE Ceramics X (Luli X)",
+)
+
 internal object RoseEarfreeI5MiLinkCardAdapter : WindNoiseToggleMiLinkCardAdapter(
     presentationId = RoseEarfreeI5Adapter.PRESENTATION_ID,
     modelLabel = "ROSE EARFREE protocol family",

--- a/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
@@ -59,6 +59,7 @@ internal data class MiLinkCardEnvironment(
 internal object MiLinkCardAdapterRegistry {
     private val adapters = listOf(
         StarRingUltraMiLinkCardAdapter,
+        RoseLuliXMiLinkCardAdapter,
         RoseEarfreeI5MiLinkCardAdapter,
         RoseBudsFeelMk2MiLinkCardAdapter,
         NiceHckOrigMiLinkCardAdapter,

--- a/system-module/src/main/java/dev/hyperears/runtime/EarbudChannel.kt
+++ b/system-module/src/main/java/dev/hyperears/runtime/EarbudChannel.kt
@@ -24,8 +24,11 @@ import dev.hyperears.integration.GattPeerIdentity
 import dev.hyperears.integration.GattPeerSelection
 import dev.hyperears.integration.GattScanFilterSpec
 import dev.hyperears.integration.GattTransportSpec
+import dev.hyperears.integration.GattWriteMode
 import dev.hyperears.integration.L2capEndpointSpec
 import dev.hyperears.integration.RfcommEndpointSpec
+import dev.hyperears.hook.ModuleLog
+import dev.hyperears.hook.maskBluetoothAddress
 import java.io.Closeable
 import java.io.IOException
 import java.lang.reflect.InvocationTargetException
@@ -324,6 +327,10 @@ private class AndroidGattChannel(
                     terminate(IOException("GATT connection status=$status"))
 
                 newState == BluetoothProfile.STATE_CONNECTED -> {
+                    ModuleLog.debug(
+                        "GattDiscovery",
+                        "GATT connected address=${maskBluetoothAddress(gatt.device.address)}",
+                    )
                     if (!gatt.discoverServices()) {
                         terminate(IOException("GATT service discovery did not start"))
                     }
@@ -341,6 +348,18 @@ private class AndroidGattChannel(
                 return
             }
 
+            val discoveredServices = gatt.services.joinToString(",") { service ->
+                val characteristics = service.characteristics.joinToString(",") {
+                    "${it.uuid}#${it.instanceId}/properties=0x${it.properties.toString(16)}"
+                }
+                "${service.uuid}[$characteristics]"
+            }
+            ModuleLog.debug(
+                "GattDiscovery",
+                "GATT services discovered address=${maskBluetoothAddress(gatt.device.address)} " +
+                    "services=${discoveredServices.ifEmpty { "<none>" }}",
+            )
+
             val requestedService = spec.serviceUuid?.let(UUID::fromString)
             val service = requestedService?.let(gatt::getService)
             if (requestedService != null && service == null) {
@@ -356,14 +375,22 @@ private class AndroidGattChannel(
             }
             val characteristics = service?.characteristics
                 ?: gatt.services.flatMap(BluetoothGattService::getCharacteristics)
+            val writeUuid = spec.writeCharacteristicUuid?.let(UUID::fromString)
+            val notifyUuid = spec.notifyCharacteristicUuid?.let(UUID::fromString)
             val write = characteristics.resolve(
-                uuid = UUID.fromString(spec.writeCharacteristicUuid),
+                uuid = writeUuid,
                 instanceId = spec.writeInstanceId,
             ) { it.canWrite() }
             val notify = characteristics.resolve(
-                uuid = UUID.fromString(spec.notifyCharacteristicUuid),
+                uuid = notifyUuid,
                 instanceId = spec.notifyInstanceId,
             ) { it.canNotify() }
+            ModuleLog.debug(
+                "GattDiscovery",
+                "GATT characteristics selected address=${maskBluetoothAddress(gatt.device.address)} " +
+                    "write=${write?.describe() ?: "<none>"} " +
+                    "notify=${notify?.describe() ?: "<none>"}",
+            )
             if (write == null || notify == null) {
                 val discovered = characteristics.joinToString(prefix = "[", postfix = "]") {
                     it.describe()
@@ -371,8 +398,8 @@ private class AndroidGattChannel(
                 terminate(
                     IOException(
                         "GATT characteristics unavailable " +
-                            "write=${spec.writeCharacteristicUuid}/${spec.writeInstanceId} " +
-                            "notify=${spec.notifyCharacteristicUuid}/${spec.notifyInstanceId}; " +
+                            "write=${spec.writeCharacteristicUuid ?: "<any>"}/${spec.writeInstanceId} " +
+                            "notify=${spec.notifyCharacteristicUuid ?: "<any>"}/${spec.notifyInstanceId}; " +
                             "discovered=$discovered",
                     ),
                 )
@@ -389,7 +416,7 @@ private class AndroidGattChannel(
             }
             val cccd = notify.getDescriptor(CLIENT_CHARACTERISTIC_CONFIGURATION_UUID)
             if (cccd == null) {
-                connectCompletion.complete(Unit)
+                terminate(IOException("GATT notify characteristic has no CCCD"))
                 return
             }
             val started =
@@ -407,6 +434,11 @@ private class AndroidGattChannel(
                 return
             }
             if (status == BluetoothGatt.GATT_SUCCESS) {
+                ModuleLog.debug(
+                    "GattDiscovery",
+                    "GATT notifications enabled address=${maskBluetoothAddress(gatt.device.address)} " +
+                        "descriptor=${descriptor.uuid}",
+                )
                 connectCompletion.complete(Unit)
             } else {
                 terminate(IOException("GATT CCCD write status=$status"))
@@ -488,6 +520,7 @@ private class AndroidGattChannel(
             ?: throw IOException("BLE scanner is unavailable")
         val completion = CompletableDeferred<BluetoothDevice>()
         peerResolution = completion
+        val loggedCandidates = HashSet<String>()
         val callback = object : ScanCallback() {
             override fun onScanResult(callbackType: Int, result: ScanResult) {
                 accept(result)
@@ -498,6 +531,10 @@ private class AndroidGattChannel(
             }
 
             override fun onScanFailed(errorCode: Int) {
+                ModuleLog.warn(
+                    "GattScan",
+                    "companion scan failed endpoint=${spec.id} error=$errorCode",
+                )
                 completion.completeExceptionally(
                     IOException("BLE companion scan failed with error=$errorCode"),
                 )
@@ -506,20 +543,65 @@ private class AndroidGattChannel(
             private fun accept(result: ScanResult) {
                 if (completion.isCompleted || result.device.sameAddressAs(sessionDevice)) return
                 val candidate = result.toGattPeerIdentity()
-                if (selection.matcher.matches(sessionIdentity, candidate)) {
+                val matched = selection.matcher.matches(sessionIdentity, candidate)
+                val reason = selection.matcher.matchReason(sessionIdentity, candidate)
+                    ?: if (matched) "matcher" else "none"
+                val candidateKey = candidate.deviceAddress ?: "device-${result.device.hashCode()}"
+                if (loggedCandidates.add(candidateKey)) {
+                    val services = candidate.serviceUuids
+                        .sorted()
+                        .joinToString(",")
+                        .ifEmpty { "<none>" }
+                    val manufacturerData = candidate.manufacturerData.entries
+                        .sortedBy { it.key }
+                        .joinToString(",") { (id, bytes) ->
+                            val payload = bytes.joinToString(separator = "") {
+                                "%02X".format(it.toInt() and 0xFF)
+                            }
+                            "0x${id.toString(16).padStart(4, '0')}:$payload"
+                        }
+                        .ifEmpty { "<none>" }
+                    ModuleLog.debug(
+                        "GattScan",
+                        "candidate address=${maskBluetoothAddress(candidate.deviceAddress)} " +
+                            "name=${candidate.deviceName ?: "<none>"} rssi=${result.rssi} " +
+                            "serviceUuids=$services manufacturerData=$manufacturerData " +
+                            "candidateReason=$reason",
+                    )
+                }
+                if (matched) {
+                    ModuleLog.debug(
+                        "GattScan",
+                        "companion matched endpoint=${spec.id} " +
+                            "address=${maskBluetoothAddress(candidate.deviceAddress)} " +
+                            "name=${candidate.deviceName ?: "<none>"} reason=$reason",
+                    )
                     completion.complete(result.device)
                 }
             }
         }
-        val scanFilter = selection.filter.toAndroidScanFilter()
+        val scanFilters = if (
+            selection.filter.manufacturerId == null && selection.filter.serviceUuid == null
+        ) {
+            // Device names are intentionally matched from ScanResult in software. Passing a
+            // device-name-only spec as an empty ScanFilter can suppress advertisements on some
+            // Android Bluetooth stacks, so use the platform's explicit unfiltered form.
+            emptyList()
+        } else {
+            listOf(selection.filter.toAndroidScanFilter())
+        }
         val scanSettings = ScanSettings.Builder()
             .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
             .build()
         try {
-            scanner.startScan(listOf(scanFilter), scanSettings, callback)
+            scanner.startScan(scanFilters, scanSettings, callback)
             return try {
                 withTimeout(selection.scanTimeoutMs) { completion.await() }
             } catch (error: TimeoutCancellationException) {
+                ModuleLog.warn(
+                    "GattScan",
+                    "companion scan timed out endpoint=${spec.id} candidates=${loggedCandidates.size}",
+                )
                 throw IOException(
                     "BLE companion endpoint was not found within ${selection.scanTimeoutMs}ms",
                     error,
@@ -549,12 +631,26 @@ private class AndroidGattChannel(
         writeMutex.withLock {
             val active = gatt ?: error("GATT is not connected")
             val characteristic = writeCharacteristic ?: error("GATT write characteristic is not ready")
+            val writeType = when (spec.writeMode) {
+                GattWriteMode.WITH_RESPONSE -> BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
+                GattWriteMode.WITHOUT_RESPONSE -> BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+            }
+            if (spec.writeMode == GattWriteMode.WITHOUT_RESPONSE) {
+                val started = active.writeCharacteristic(
+                    characteristic,
+                    bytes,
+                    writeType,
+                ) == BluetoothStatusCodes.SUCCESS
+                if (!started) throw IOException("GATT write command did not start")
+                return@withLock
+            }
+
             val completion = CompletableDeferred<Unit>()
             pendingWrite = completion
             val started = active.writeCharacteristic(
                 characteristic,
                 bytes,
-                BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT,
+                writeType,
             ) == BluetoothStatusCodes.SUCCESS
             if (!started) {
                 pendingWrite = null
@@ -591,14 +687,15 @@ private class AndroidGattChannel(
     }
 
     private fun List<BluetoothGattCharacteristic>.resolve(
-        uuid: UUID,
+        uuid: UUID?,
         instanceId: Int?,
         predicate: (BluetoothGattCharacteristic) -> Boolean,
     ): BluetoothGattCharacteristic? =
         firstOrNull {
-            instanceId != null && it.uuid == uuid && it.instanceId == instanceId && predicate(it)
-        } ?: firstOrNull {
-            it.uuid == uuid && predicate(it)
+            instanceId != null && it.instanceId == instanceId &&
+                (uuid == null || it.uuid == uuid) && predicate(it)
+        } ?: uuid?.let { requestedUuid ->
+            firstOrNull { it.uuid == requestedUuid && predicate(it) }
         }
 
     private fun BluetoothGattCharacteristic.canWrite(): Boolean =
@@ -620,6 +717,9 @@ private class AndroidGattChannel(
         val builder = ScanFilter.Builder()
         manufacturerId?.let { builder.setManufacturerData(it, byteArrayOf()) }
         serviceUuid?.let { builder.setServiceUuid(ParcelUuid.fromString(it)) }
+        // Device names are matched in software from ScanResult plus BluetoothDevice cache. Some
+        // companion endpoints expose their name only after GATT discovery, so platform name
+        // filtering can suppress an otherwise valid candidate before the Adapter sees it.
         return builder.build()
     }
 

--- a/system-module/src/main/java/dev/hyperears/runtime/EarbudDeviceSession.kt
+++ b/system-module/src/main/java/dev/hyperears/runtime/EarbudDeviceSession.kt
@@ -524,7 +524,8 @@ internal class EarbudDeviceSession(
                 lastError = error
                 ModuleLog.debug(
                     COMPONENT,
-                    "transport ${transport.id} failed: ${error.javaClass.simpleName}",
+                    "transport ${transport.id} failed: " +
+                        "${error.javaClass.simpleName}:${error.message ?: "<no-message>"}",
                 )
             }
         }

--- a/system-module/src/main/java/dev/hyperears/ui/about/AboutScreen.kt
+++ b/system-module/src/main/java/dev/hyperears/ui/about/AboutScreen.kt
@@ -224,6 +224,12 @@ private val supportBrands = listOf(
                 noiseControl = "降噪 / 关闭 / 通透 / 抗风噪",
             ),
             SupportEntry(
+                name = "ROSE Ceramics X（琉璃 X）",
+                evidence = EvidenceLevel.VERIFIED,
+                battery = BatteryCapability.SYSTEM,
+                noiseControl = "降噪 / 关闭 / 通透 / 抗风噪",
+            ),
+            SupportEntry(
                 name = "ROSE Ceramics Ultra（琉璃 Ultra）",
                 evidence = EvidenceLevel.VERIFIED,
                 battery = BatteryCapability.COMPONENT,


### PR DESCRIPTION
                                                                                **vide coding By dsh gpt5.6 sol** 
现在milink只有三个状态可以切换 缺少抗风降噪卡片

为 ROSE Ceramics X / Luli X 新增耳机集成支持：通过主耳机名称匹配 `ROSE Ceramics X` / `ROSE Luli X`，并自动发现名称缺失的 `CERAMICS X BLE` 配套 BLE 控制端点。收到合法的 Ceramics X 协议状态响应并确认能力后，向 MiLink 提供系统电量和标准降噪控制。

本 PR 不改变已经确认的协议语义，不暴露厂商私有调节项，也不将抗风噪作为 MiLink 原生第四个并列模式。

## 改动

### 主模块（integration + protocol）

- 新增 `RoseLuliXAdapter`：
  - 匹配 `ROSE Ceramics X` 和 `ROSE Luli X`。
  - 明确排除系统原生耳机设备。
  - 私有能力仍需收到合法协议状态响应后才开放。
  - 使用系统聚合电量作为电量来源。
  - 仅暴露标准 ANC、关闭、通透和抗风噪控制能力。
- 新增 `RoseCeramicsXWireCodec`：
  - 支持 Ceramics X 查询当前噪声模式。
  - 支持 ANC、通透、抗风噪和关闭四种协议模式。
  - 支持 `0x27` 查询响应和 `0x28` 异步状态上报。
  - 支持 `0x2C` 模式写入。
  - 严格校验帧长度、命令字、字段和噪声模式值。
- 确认并接入实测 BLE GATT 端点：
  - Service：`0000fdb3-0000-1000-8000-00805f9b34fb`
  - Write Characteristic：`0000ff16-0000-1000-8000-00805f9b34fb`
  - Notify Characteristic：`0000ff17-0000-1000-8000-00805f9b34fb`
  - Write instance：`0x0015`
  - Notify instance：`0x0017`
  - 写入模式：Write Without Response
- 保留完整 GATT 服务发现和特征选择日志。
- 增加 CCCD 通知订阅：
  - 订阅成功后才认为 GATT 通道就绪。
  - 缺少 CCCD 或通知启用失败时，连接进入失败状态。
- 增强配套 BLE 设备匹配：
  - 支持设备名称为 `CERAMICS X BLE` 的候选端点。
  - 支持名称缺失但包含实测临时厂商数据的候选端点。
  - 使用软件匹配，避免平台扫描过滤器因设备名称未及时暴露而漏掉候选设备。
  - 输出 `device-name` 或 `manufacturer-id` 匹配原因。
- GATT 特征选择同时校验：
  - Service UUID
  - Characteristic UUID
  - Instance ID
  - Characteristic properties
- 更新 `EarbudChannel` 和 `EarbudDeviceSession` 的诊断信息，保留服务发现、特征选择、通知订阅及传输失败原因。
- 未增加额外宿主进程 Hook、轮询循环或独立后台服务。

### MiLink 映射

- 保持 MiLink 原生三态控制结构：
  - 关闭
  - 降噪
  - 通透
- 抗风噪沿用原项目已有的扩展开关式展示，不改造成第四个原生并列项目。
- Ceramics X 的四种协议模式仍然可以通过私有协议读写：
  - `0x00`：抗风噪
  - `0x01`：降噪
  - `0x02`：通透
  - `0x03`：关闭
- MiLink 不暴露降噪强度、通透百分比、自适应 ANC 或其他厂商私有调节项。

## 实机验证

### 设备识别

- 主耳机名称为 `ROSE Ceramics X` 时，`RoseLuliXAdapter` 匹配成功。
- 主耳机名称为 `ROSE Luli X` 时，别名匹配成功。
- 配套 BLE 端点名称为 `CERAMICS X BLE` 时，匹配成功。
- 配套 BLE 端点名称缺失时，可通过实测厂商数据匹配成功。
- 无关 BLE 设备不会被误匹配。
- 已确认 `companion matched` 日志能够正常出现。

### GATT 连接

- 配套 BLE 端点连接成功。
- GATT 服务发现成功。
- 已确认实测服务中包含：

```text
FDB3
  FF16 #21  properties=0x6
  FF17 #23  properties=0x12
```

- Characteristic 选择使用 `FF16#21` 和 `FF17#23`。
- CCCD 写入和通知订阅逻辑已接入。
- 修复了此前使用临时 `FFF2` / `FFF4` UUID 导致的特征选择失败。

### 噪声控制

- 当前模式查询成功。
- ANC、关闭、通透和抗风噪四种协议值均已完成编码和解析。
- 模式变更通过 Ceramics X `0x2C` 写入命令发送。
- 状态通过 `0x27` / `0x28` 响应回读确认。
- MiLink 界面继续显示标准三态，并通过现有扩展逻辑提供抗风噪控制。

## 构建与测试

已通过：

```text
:protocol:testDebugUnitTest
:integration:testDebugUnitTest
:system-module:testDebugUnitTest
:system-module:assembleDebug
```

同时增加或更新以下测试覆盖：

- Ceramics X 名称和别名匹配。
- 无名配套 BLE 设备的厂商数据匹配。
- 无关 BLE 设备拒绝。
- GATT Service、Write Characteristic 和 Notify Characteristic UUID。
- GATT instance ID `0x0015` / `0x0017`。
- ANC、通透、抗风噪和关闭模式解析。
- 模式控制命令编码。
- 协议状态确认后才开放噪声控制能力。

## 风险与回滚

- 当前实机验证重点为 `ROSE Ceramics X`，其他 ROSE 型号不自动继承该协议。
- `0x8418` 目前仅作为实测配套端点识别提示使用，不将其描述为已确认的官方厂商标识。
- 名称匹配只选择候选 Adapter；在收到合法 Ceramics X 状态响应前，私有噪声控制保持不可用。
- 若 GATT 服务、Characteristic UUID、instance ID 或属性发生变化，连接会停留在特征选择失败阶段，不会向错误通道写入数据。
- 禁用 `rose-luli-x-gatt` Adapter 后，相关设备可回退到标准耳机路径。
- MiLink 仍采用原有三态展示和抗风噪扩展，不影响其他型号的四态 Edifier 卡片。

## 说明

本 PR 基于实测的 ROSE Ceramics X BLE 广播、GATT 服务表和协议帧整理完成。未附加专有 APK、反编译包、凭据、完整蓝牙地址或受版权保护的产品素材。
