### PR TITLE
Expose charge-case battery & wire FitClip Ultra game-mode capability

### DIFF
--- a/integration/src/main/java/dev/hyperears/integration/BoseEarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/BoseEarbudAdapter.kt
@@ -74,13 +74,14 @@ open class BoseEarbudAdapter(
     override fun onCapabilitiesIdentified(
         battery: Boolean,
         noiseModes: Set<NoiseMode>,
+        gameMode: Boolean,
     ): HandshakeResult? {
         val session = protocolSession as? BoseBmapProtocolSession ?: return null
         val discovered = session.discoveredConfig
-            ?: return super.onCapabilitiesIdentified(battery, noiseModes)
+            ?: return super.onCapabilitiesIdentified(battery, noiseModes, gameMode)
         val nextConfig = wireConfig?.copy(noiseControl = discovered.noiseControl) ?: discovered
         if (wireConfig == nextConfig) {
-            return super.onCapabilitiesIdentified(battery, noiseModes)
+            return super.onCapabilitiesIdentified(battery, noiseModes, gameMode)
         }
         val next = BoseRuntimeAdapterFactory.create(
             configuration = nextConfig,

--- a/integration/src/main/java/dev/hyperears/integration/ControlRequest.kt
+++ b/integration/src/main/java/dev/hyperears/integration/ControlRequest.kt
@@ -33,6 +33,12 @@ sealed interface StandardControlRequest : ControlRequest {
     data class SetNoiseMode(
         val mode: NoiseMode,
     ) : StandardControlRequest
+
+    @Serializable
+    @SerialName("standard.set_game_mode")
+    data class SetGameMode(
+        val enabled: Boolean,
+    ) : StandardControlRequest
 }
 
 /**
@@ -72,6 +78,9 @@ object StandardControlRequestContract : ControlRequestContract {
         request is StandardControlRequest.SetNoiseMode ->
             adapter.effectiveCapabilities().noiseControl &&
                 request.mode in adapter.effectiveSupportedNoiseModes()
+
+        request is StandardControlRequest.SetGameMode ->
+            adapter.effectiveCapabilities().gameModeControl
 
         else -> false
     }

--- a/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
@@ -203,7 +203,7 @@ abstract class EarbudAdapter(
                 }
 
                 is ProtocolEvent.CapabilitiesIdentified -> {
-                    onCapabilitiesIdentified(event.battery, event.noiseModes)
+                    onCapabilitiesIdentified(event.battery, event.noiseModes, event.gameMode)
                         ?.let { handshake = it }
                 }
 
@@ -247,6 +247,7 @@ abstract class EarbudAdapter(
     protected open fun onCapabilitiesIdentified(
         battery: Boolean,
         noiseModes: Set<NoiseMode>,
+        gameMode: Boolean = false,
     ): HandshakeResult? {
         val nextModes = effectiveSupportedNoiseModes() + noiseModes
         val base = effectiveCapabilities()
@@ -255,6 +256,7 @@ abstract class EarbudAdapter(
             battery = base.battery || battery,
             noiseControl = nextModes.isNotEmpty(),
             windNoiseControl = NoiseMode.WIND in nextModes,
+            gameModeControl = base.gameModeControl || gameMode,
         )
         return null
     }
@@ -283,6 +285,10 @@ abstract class EarbudAdapter(
     open fun controlPolicy(request: ControlRequest): ControlExecutionPolicy = when (request) {
         is StandardControlRequest.SetNoiseMode -> ControlExecutionPolicy(
             stateAfterWrite = NoiseModeFeatureState(request.mode),
+        )
+
+        is StandardControlRequest.SetGameMode -> ControlExecutionPolicy(
+            stateAfterWrite = GameModeFeatureState(request.enabled),
         )
 
         else -> ControlExecutionPolicy()

--- a/integration/src/main/java/dev/hyperears/integration/EarbudModel.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EarbudModel.kt
@@ -101,6 +101,19 @@ data class NoiseModeFeatureState(
     }
 }
 
+@Serializable
+@SerialName("standard.game_mode")
+data class GameModeFeatureState(
+    val enabled: Boolean,
+) : DeviceFeatureState {
+    @Transient
+    override val featureId: String = FEATURE_ID
+
+    companion object {
+        const val FEATURE_ID = "standard.game_mode"
+    }
+}
+
 /** Immutable state collection with replacement semantics per feature identity. */
 @Serializable
 data class DeviceFeatureSnapshot(
@@ -138,7 +151,8 @@ fun interface DeviceFeatureStateContract {
 object StandardDeviceFeatureStateContract : DeviceFeatureStateContract {
     override fun accepts(adapter: EarbudAdapter, state: DeviceFeatureState): Boolean =
         state.featureId == BatteryFeatureState.FEATURE_ID ||
-            state.featureId == NoiseModeFeatureState.FEATURE_ID
+            state.featureId == NoiseModeFeatureState.FEATURE_ID ||
+            state.featureId == GameModeFeatureState.FEATURE_ID
 }
 
 /** Adds a family/model feature predicate without weakening standard state handling. */
@@ -284,6 +298,7 @@ sealed interface ProtocolEvent {
     data class CapabilitiesIdentified(
         val battery: Boolean,
         val noiseModes: Set<NoiseMode> = emptySet(),
+        val gameMode: Boolean = false,
     ) : ProtocolEvent
 
     data class FeatureStateChanged(val state: DeviceFeatureState) : ProtocolEvent
@@ -476,6 +491,7 @@ data class EarbudCapabilities(
     val spatialAudio: Boolean = false,
     val wearDetection: Boolean = false,
     val findDevice: Boolean = false,
+    val gameModeControl: Boolean = false,
 )
 
 /** One vendor control application that may take ownership of the private headset protocol. */

--- a/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
@@ -192,8 +192,8 @@ class EdifierFitClipUltraAdapter : EdifierEarbudAdapter() {
         batteryQueries = listOf(EdifierBatteryQuery.DEVICE_STATE),
         batteryProjection = EdifierBatteryProjection.TWS_AGGREGATE,
         ancDialects = emptyList(),
+        gameModeQuery = true,
     )
-
     override fun matches(identity: EarbudIdentity): Boolean {
         if (!identity.standardHeadset || identity.nativeSystemEarbud) return false
         return normalizeDeviceName(identity.deviceName.orEmpty()) in MODEL_NAMES
@@ -288,6 +288,7 @@ data class EdifierWireConfig(
         EdifierAncDialects.EVO_PRO,
     ),
     val preferredAncIndex: Int? = null,
+    val gameModeQuery: Boolean = false,
 ) {
     init {
         require(batteryQueries.isNotEmpty())
@@ -318,6 +319,9 @@ private class EdifierProtocolSession(
             add(EdifierWireCodec.queryAnc)
         }
         add(EdifierWireCodec.queryFunction)
+        if (configuration.gameModeQuery) {
+            add(EdifierWireCodec.queryGameState)
+        }
     }
 
     override fun encode(request: ControlRequest): List<ByteArray> = when {
@@ -325,6 +329,9 @@ private class EdifierProtocolSession(
             addAll(configuration.batteryQueries.map { batteryQueryPacket(it) })
             if (configuration.ancDialects.isNotEmpty()) {
                 add(EdifierWireCodec.queryAnc)
+            }
+            if (configuration.gameModeQuery) {
+                add(EdifierWireCodec.queryGameState)
             }
         }
         request is StandardControlRequest.SetNoiseMode -> {
@@ -336,6 +343,8 @@ private class EdifierProtocolSession(
                 emptyList()
             }
         }
+        request is StandardControlRequest.SetGameMode ->
+            listOf(EdifierWireCodec.setGameMode(request.enabled))
 
         else -> emptyList()
     }
@@ -345,6 +354,7 @@ private class EdifierProtocolSession(
         // acknowledgement. Skip the extra readback round-trip to reduce perceived latency.
         request === StandardControlRequest.Refresh -> emptyList()
         request is StandardControlRequest.SetNoiseMode -> emptyList()
+        request is StandardControlRequest.SetGameMode -> listOf(EdifierWireCodec.queryGameState)
         else -> emptyList()
     }
 
@@ -394,6 +404,13 @@ private class EdifierProtocolSession(
                 return@forEach
             }
 
+            // Game-mode state from 0x08 query or 0x09 set response
+            EdifierWireCodec.parseGameModeState(frame)?.let { enabled ->
+                add(ProtocolEvent.CapabilitiesIdentified(battery = false, gameMode = true))
+                add(ProtocolEvent.FeatureStateChanged(GameModeFeatureState(enabled)))
+                return@forEach
+            }
+
             add(
                 ProtocolEvent.UnknownFrame(
                     version = 0,
@@ -428,6 +445,7 @@ private class EdifierProtocolSession(
         is EdifierWireCodec.BatteryState.TwsComponents -> EarbudBattery(
             left = BatteryReading(leftPercent, charging = false),
             right = BatteryReading(rightPercent, charging = false),
+            case = BatteryReading(casePercent, charging = caseCharging),
         )
     }
 

--- a/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
@@ -188,6 +188,10 @@ class EdifierFitClipUltraAdapter : EdifierEarbudAdapter() {
     override val id: String = ID
     override val displayName: String = "Edifier FitClip Ultra"
     override val resolution: AdapterResolution = AdapterResolution.EXACT_MATCH
+    override val miLinkCardPresentationId: MiLinkCardPresentationId?
+        get() = EdifierMiLinkPresentationIds.GAME_MODE.takeIf {
+            effectiveCapabilities().gameModeControl
+        }
     override val wireConfig: EdifierWireConfig = EdifierWireConfig(
         batteryQueries = listOf(EdifierBatteryQuery.DEVICE_STATE),
         batteryProjection = EdifierBatteryProjection.TWS_AGGREGATE,
@@ -211,6 +215,7 @@ class EdifierFitClipUltraAdapter : EdifierEarbudAdapter() {
 
 object EdifierMiLinkPresentationIds {
     val FOUR_MODE = MiLinkCardPresentationId("edifier-four-mode")
+    val GAME_MODE = MiLinkCardPresentationId("edifier-fitclip-game")
 }
 
 enum class EdifierBatteryQuery(val commandIndex: Int) {

--- a/integration/src/main/java/dev/hyperears/integration/HonorX5sProAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/HonorX5sProAdapter.kt
@@ -88,6 +88,7 @@ private class HonorX5sProProtocolSession : ProtocolSession {
                 request.depth.toWireDepth(),
             ),
         )
+        is StandardControlRequest.SetGameMode -> emptyList()
         else -> emptyList()
     }
 

--- a/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
+++ b/integration/src/test/java/dev/hyperears/integration/EarbudAdapterHierarchyTest.kt
@@ -313,6 +313,7 @@ class EarbudAdapterHierarchyTest {
             listOf(
                 EdifierWireCodec.queryDeviceState.toList(),
                 EdifierWireCodec.queryFunction.toList(),
+                EdifierWireCodec.queryGameState.toList(),
             ),
             adapter.beginHandshake().commands.map(ByteArray::toList),
         )

--- a/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
+++ b/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
@@ -34,6 +34,7 @@ object EdifierWireCodec {
     const val CMD_NAME_QUERY = 0xC9           // 201 — query name
     const val CMD_FUNCTION_QUERY = 0xD8       // 216 — query device capabilities
     const val CMD_GAME_STATE_QUERY = 0x08     // 8   — query game mode
+    const val CMD_GAME_STATE_SET = 0x09       // 9   — set game mode
 
     // ANC ancIndex for W860NB PRO (ANC16 slot, verified on device)
     const val ANC_INDEX = 0x10
@@ -69,6 +70,8 @@ object EdifierWireCodec {
         data class TwsComponents(
             val leftPercent: Int,
             val rightPercent: Int,
+            val casePercent: Int? = null,
+            val caseCharging: Boolean = false,
         ) : BatteryState
     }
 
@@ -84,11 +87,20 @@ object EdifierWireCodec {
     val queryDeviceState: ByteArray = packet(CMD_DEVICE_STATE_QUERY)
     val queryFunction: ByteArray = packet(CMD_FUNCTION_QUERY)
     val queryVersion: ByteArray = packet(CMD_VERSION_QUERY)
+    val queryGameState: ByteArray = packet(CMD_GAME_STATE_QUERY)
 
     fun setAnc(ancValue: Int, ancIndex: Int = ANC_INDEX): ByteArray =
         packet(
             CMD_ANC_SET,
             byteArrayOf(ancIndex.toByte(), ancValue.toByte()),
+            xorKey = RESPONSE_XOR_KEY,
+        )
+
+    /** Game mode: payload is a single byte 1=on / 0=off, XOR-encrypted like ANC. */
+    fun setGameMode(enabled: Boolean): ByteArray =
+        packet(
+            CMD_GAME_STATE_SET,
+            byteArrayOf(if (enabled) 0x01 else 0x00),
             xorKey = RESPONSE_XOR_KEY,
         )
 
@@ -107,15 +119,25 @@ object EdifierWireCodec {
             // Captured Evo Pro response:
             // BB EC F2 00 06 A6 C1 C7 A5 A6 B4 CC
             // decrypted payload: 03 64 62 00 03 11. Byte 0 is metadata; bytes 1/2 are the
-            // independently displayed left/right levels. No case field is claimed yet.
+            // independently displayed left/right levels; byte 3 is charge-case percent and
+            // byte 4 is the case state (1=charging, 2=not, 3=offline).
             CMD_DEVICE_STATE_QUERY -> frame.payload
                 .takeIf { it.size >= TWS_COMPONENT_FIELD_COUNT }
                 ?.let { payload ->
                     val left = payload[TWS_LEFT_BATTERY_OFFSET].decryptPercent() ?: return@let null
                     val right = payload[TWS_RIGHT_BATTERY_OFFSET].decryptPercent() ?: return@let null
+                    val caseState = payload.getOrNull(TWS_CASE_STATE_OFFSET)
+                        ?.unsigned()?.let { it xor RESPONSE_XOR_KEY }
+                    // Verified on-device (FitClip Ultra): byte3 = case percent, byte4 = case
+                    // state (1=charging, 2=not, 3=offline). Case omitted when state is offline.
+                    val casePercent = payload.getOrNull(TWS_CASE_BATTERY_OFFSET)
+                        ?.decryptPercent()
+                        ?.takeIf { caseState != TWS_CASE_STATE_OFFLINE }
                     BatteryState.TwsComponents(
                         leftPercent = left,
                         rightPercent = right,
+                        casePercent = casePercent,
+                        caseCharging = caseState == TWS_CASE_STATE_CHARGING,
                     )
                 }
 
@@ -137,6 +159,20 @@ object EdifierWireCodec {
         val mode = (frame.payload[0].unsigned() xor RESPONSE_XOR_KEY)
         val level = frame.payload.getOrNull(1)?.unsigned()?.let { it xor RESPONSE_XOR_KEY }
         return AncState(mode = mode, level = level)
+    }
+
+    /** Parses game-mode state from a 0x08 query or 0x09 set response (1=on, 0=off). */
+    fun parseGameModeState(frame: Frame): Boolean? {
+        if (!isProtocolResponse(frame)) return null
+        if (frame.commandIndex != CMD_GAME_STATE_QUERY && frame.commandIndex != CMD_GAME_STATE_SET) {
+            return null
+        }
+        val value = frame.payload.firstOrNull()?.unsigned()?.let { it xor RESPONSE_XOR_KEY } ?: return null
+        return when (value) {
+            0 -> false
+            1 -> true
+            else -> null
+        }
     }
 
     /** A device-originated BES/Edifier frame eligible to establish protocol evidence. */
@@ -281,4 +317,10 @@ object EdifierWireCodec {
     private const val TWS_COMPONENT_FIELD_COUNT = 3
     private const val TWS_LEFT_BATTERY_OFFSET = 1
     private const val TWS_RIGHT_BATTERY_OFFSET = 2
+    private const val TWS_CASE_BATTERY_OFFSET = 3
+    private const val TWS_CASE_STATE_OFFSET = 4
+
+    // BoxStateEnum: 1=Charging, 2=NotCharging, 3=Offline(undetectable).
+    private const val TWS_CASE_STATE_CHARGING = 1
+    private const val TWS_CASE_STATE_OFFLINE = 3
 }

--- a/system-module/src/main/AndroidManifest.xml
+++ b/system-module/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="io.github.libxposed.permission.BIND_XPOSED_SERVICE" />
 
     <queries>
         <package android:name="com.android.bluetooth" />

--- a/system-module/src/main/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapter.kt
@@ -1,0 +1,278 @@
+package dev.hyperears.hook
+
+import android.content.Context
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CompoundButton
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.view.isVisible
+import dev.hyperears.integration.EarbudState
+import dev.hyperears.integration.GameModeFeatureState
+import dev.hyperears.integration.EdifierMiLinkPresentationIds
+import dev.hyperears.integration.MiLinkCardPresentationId
+import dev.hyperears.integration.StandardControlRequest
+import java.lang.ref.WeakReference
+
+/**
+ * Adds a protocol-confirmed game-mode switch to MiLink's native headset card for Edifier
+ * models that expose a game-mode control capability but no ANC branch (such as FitClip Ultra).
+ *
+ * Unlike the wind-noise toggle, this presentation is independent of MiLink's ANC item layout:
+ * it locates the card's title row through either native title contract and injects the game-mode
+ * switch beside it. When no title anchor is found the adapter returns null (safe no-op), so the
+ * presentation never draws an imitation in an unknown layout. The switch is enabled only while
+ * the authoritative adapter reports the game-mode capability; its checked state is always rendered
+ * from [EarbudState].
+ */
+internal open class FitClipGameModeMiLinkCardAdapter(
+    final override val presentationId: MiLinkCardPresentationId,
+    private val modelLabel: String,
+) : MiLinkCardAdapter {
+
+    override fun bind(
+        root: View,
+        address: String,
+        environment: MiLinkCardEnvironment,
+    ): MiLinkCardBinding? {
+        val host = resolveNativeTitle(root) ?: return null
+        val title = host.title
+        val parent = title.parent as? ViewGroup ?: return null
+        val index = parent.indexOfChild(title).takeIf { it >= 0 } ?: return null
+        val originalParams = title.layoutParams
+        val originalWidth = originalParams.width
+
+        parent.removeViewAt(index)
+        val wrapper = FrameLayout(root.context).apply {
+            layoutParams = originalParams.apply {
+                width = ViewGroup.LayoutParams.MATCH_PARENT
+            }
+        }
+        title.layoutParams = FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT,
+        )
+        wrapper.addView(title)
+
+        val accessory = LinearLayout(root.context).apply {
+            gravity = Gravity.CENTER_VERTICAL
+            orientation = LinearLayout.HORIZONTAL
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+        }
+        val label = TextView(root.context).apply {
+            text = GAME_MODE_LABEL
+            setTextColor(title.currentTextColor)
+            setTextSize(TypedValue.COMPLEX_UNIT_PX, title.textSize)
+            typeface = title.typeface
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+            setPadding(0, 0, root.context.dp(LABEL_END_PADDING_DP), 0)
+        }
+        val toggle = createHostToggle(root.context, environment.hostClassLoader).apply {
+            contentDescription = GAME_MODE_LABEL
+            isSaveEnabled = false
+        }
+        accessory.addView(label)
+        accessory.addView(toggle)
+        wrapper.addView(
+            accessory,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                Gravity.END or Gravity.CENTER_VERTICAL,
+            ),
+        )
+        parent.addView(wrapper, index)
+
+        return Binding(
+            parent = parent,
+            originalIndex = index,
+            originalLayoutParams = originalParams,
+            originalWidth = originalWidth,
+            wrapper = wrapper,
+            title = title,
+            accessory = accessory,
+            toggle = toggle,
+            address = address,
+            environment = environment,
+        ).also { binding ->
+            toggle.setOnCheckedChangeListener(binding::onToggleChanged)
+            ModuleLog.debug(
+                "MiLinkUi",
+                "bound $modelLabel game-mode switch layout=${host.generation.logName}",
+            )
+        }
+    }
+
+    private class Binding(
+        parent: ViewGroup,
+        private val originalIndex: Int,
+        private val originalLayoutParams: ViewGroup.LayoutParams,
+        private val originalWidth: Int,
+        wrapper: View,
+        title: View,
+        accessory: View,
+        toggle: CompoundButton,
+        private val address: String,
+        private val environment: MiLinkCardEnvironment,
+    ) : MiLinkCardBinding {
+        private val parent = WeakReference(parent)
+        private val wrapper = WeakReference(wrapper)
+        private val title = WeakReference(title)
+        private val accessory = WeakReference(accessory)
+        private val toggle = WeakReference(toggle)
+        private var rendering = false
+
+        override fun render(state: EarbudState) {
+            val wrapper = wrapper.get() ?: return
+            val title = title.get() ?: return
+            val accessory = accessory.get() ?: return
+            val toggle = toggle.get() ?: return
+
+            wrapper.visibility = if (state.sessionActive) View.VISIBLE else View.GONE
+            accessory.visibility =
+                if (title.isVisible && state.sessionActive) View.VISIBLE else View.GONE
+
+            val toggleState = GameModeToggleControlPolicy.render(state)
+            rendering = true
+            try {
+                toggle.isChecked = toggleState.checked
+                toggle.isEnabled = toggleState.enabled
+                toggle.alpha = if (toggle.isEnabled) ENABLED_ALPHA else DISABLED_ALPHA
+                accessory.alpha = if (toggle.isEnabled) ENABLED_ALPHA else DISABLED_ALPHA
+            } finally {
+                rendering = false
+            }
+        }
+
+        fun onToggleChanged(button: CompoundButton, checked: Boolean) {
+            if (rendering) return
+            val current = environment.stateProvider(address)
+            val currentToggleState = GameModeToggleControlPolicy.render(current)
+
+            // A UI gesture is only a request. Restore the authoritative value until the device
+            // reports the new game-mode state through the normal protocol state pipeline.
+            rendering = true
+            try {
+                button.isChecked = currentToggleState.checked
+            } finally {
+                rendering = false
+            }
+
+            val requested = GameModeToggleControlPolicy.request(current, checked) ?: return
+            environment.controlSender(
+                address,
+                StandardControlRequest.SetGameMode(requested),
+            )
+        }
+
+        override fun unbind() {
+            val parent = parent.get() ?: return
+            val wrapper = wrapper.get() ?: return
+            val title = title.get() ?: return
+            val toggle = toggle.get()
+            toggle?.setOnCheckedChangeListener(null)
+            if (wrapper.parent !== parent) return
+
+            (title.parent as? ViewGroup)?.removeView(title)
+            parent.removeView(wrapper)
+            originalLayoutParams.width = originalWidth
+            title.layoutParams = originalLayoutParams
+            parent.addView(title, originalIndex.coerceAtMost(parent.childCount))
+        }
+    }
+
+    private fun createHostToggle(
+        context: Context,
+        hostClassLoader: ClassLoader,
+    ): CompoundButton = runCatching {
+        Class.forName(MIUIX_SLIDING_BUTTON, true, hostClassLoader)
+            .asSubclass(CompoundButton::class.java)
+            .getConstructor(Context::class.java)
+            .newInstance(context)
+    }.getOrElse {
+        @Suppress("DEPRECATION")
+        android.widget.Switch(context)
+    }
+
+    private fun Context.dp(value: Int): Int =
+        (value * resources.displayMetrics.density).toInt()
+
+    private fun resolveNativeTitle(root: View): NativeTitle? {
+        val originalTitle = root.findMiLinkView(ORIGINAL_ANC_CARD_TITLE_ID) as? TextView
+        if (originalTitle != null) {
+            return NativeTitle(
+                generation = NativeTitleGeneration.ORIGINAL,
+                title = originalTitle,
+            )
+        }
+
+        val selectTitle = root.findMiLinkView(SELECT_ANC_CARD_TITLE_ID) as? TextView
+            ?: return null
+        return NativeTitle(
+            generation = NativeTitleGeneration.SELECT_CARD,
+            title = selectTitle,
+        )
+    }
+
+    private data class NativeTitle(
+        val generation: NativeTitleGeneration,
+        val title: TextView,
+    )
+
+    private enum class NativeTitleGeneration(val logName: String) {
+        ORIGINAL("original"),
+        SELECT_CARD("select-card"),
+    }
+
+    private companion object {
+        const val ORIGINAL_ANC_CARD_TITLE_ID = "anc_card_title"
+        const val SELECT_ANC_CARD_TITLE_ID = "anc_card_text"
+        const val MIUIX_SLIDING_BUTTON = "miuix.slidingwidget.widget.SlidingButton"
+        const val GAME_MODE_LABEL = "游戏模式"
+        const val LABEL_END_PADDING_DP = 8
+        const val ENABLED_ALPHA = 1.0f
+        const val DISABLED_ALPHA = 0.45f
+    }
+}
+/**
+ * Concrete presentation for Edifier FitClip Ultra's game-mode capability.
+ *
+ * The shared [FitClipGameModeMiLinkCardAdapter] keeps MiLink's title row intact and adds the
+ * device-specific game-mode switch beside it. This presentation is selected only after the
+ * private session confirms the game-mode capability (adapter.presentationId is null otherwise).
+ */
+internal object FitClipUltraGameModeMiLinkCardAdapter : FitClipGameModeMiLinkCardAdapter(
+    presentationId = EdifierMiLinkPresentationIds.GAME_MODE,
+    modelLabel = "Edifier FitClip Ultra",
+)
+
+/** Pure game-mode-to-switch policy; UI code contains no independent mode state. */
+internal object GameModeToggleControlPolicy {
+    data class ToggleState(
+        val checked: Boolean,
+        val enabled: Boolean,
+    )
+
+    fun render(state: EarbudState): ToggleState {
+        val gameModeOn = state.features.get<GameModeFeatureState>()?.enabled ?: false
+        return ToggleState(
+            checked = gameModeOn,
+            enabled = state.sessionActive &&
+                state.connected &&
+                (state.adapter?.capabilities?.gameModeControl == true),
+        )
+    }
+
+    fun request(state: EarbudState, checked: Boolean): Boolean? {
+        if (!render(state).enabled) return null
+        val currentOn = state.features.get<GameModeFeatureState>()?.enabled ?: false
+        return when {
+            checked && !currentOn -> true
+            !checked && currentOn -> false
+            else -> null
+        }
+    }
+}

--- a/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
@@ -66,6 +66,7 @@ internal object MiLinkCardAdapterRegistry {
         BoseAnrMiLinkCardAdapter,
         BoseTwoModeMiLinkCardAdapter,
         EdifierFourModeMiLinkCardAdapter,
+        FitClipUltraGameModeMiLinkCardAdapter,
         SonyAmbientOnlyMiLinkCardAdapter,
     )
     private val byId = adapters.associateBy(MiLinkCardAdapter::presentationId)

--- a/system-module/src/test/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapterTest.kt
+++ b/system-module/src/test/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapterTest.kt
@@ -1,0 +1,80 @@
+package dev.hyperears.hook
+
+import dev.hyperears.integration.AdapterSnapshot
+import dev.hyperears.integration.EarbudCapabilities
+import dev.hyperears.integration.EarbudState
+import dev.hyperears.integration.DeviceLifecycle
+import dev.hyperears.integration.GameModeFeatureState
+import dev.hyperears.integration.PrivateTransportState
+import dev.hyperears.integration.ProtocolHandshakeState
+import dev.hyperears.integration.SystemProfileState
+import dev.hyperears.integration.withFeature
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FitClipGameModeMiLinkCardAdapterTest {
+    private val connected = EarbudState(
+        lifecycle = DeviceLifecycle(
+            SystemProfileState.CONNECTED,
+            PrivateTransportState.NOT_REQUIRED,
+            ProtocolHandshakeState.NOT_REQUIRED,
+        ),
+        adapter = AdapterSnapshot(
+            id = "edifier-fitclip-ultra",
+            displayName = "Edifier FitClip Ultra",
+            resolution = dev.hyperears.integration.AdapterResolution.EXACT_MATCH,
+            privateProtocolRequired = true,
+            batterySource = dev.hyperears.integration.BatterySource.PRIVATE_PROTOCOL,
+            formFactor = dev.hyperears.integration.HeadsetFormFactor.TWS,
+            capabilities = EarbudCapabilities(gameModeControl = true),
+            supportedNoiseModes = emptySet(),
+            presentationId = dev.hyperears.integration.EdifierMiLinkPresentationIds.GAME_MODE,
+            transportKinds = setOf(dev.hyperears.integration.TransportKind.RFCOMM),
+        ),
+    )
+
+    @Test
+    fun gameModeSwitchRendersOnlyWhenCapabilityIsConfirmed() {
+        val on = GameModeToggleControlPolicy.render(connected.withFeature(GameModeFeatureState(enabled = true)))
+        val off = GameModeToggleControlPolicy.render(connected.withFeature(GameModeFeatureState(enabled = false)))
+
+        assertTrue(on.enabled)
+        assertTrue(on.checked)
+        assertTrue(off.enabled)
+        assertFalse(off.checked)
+    }
+
+    @Test
+    fun gameModeToggleIsDisabledWithoutConfirmedCapability() {
+        val noCapability = connected.copy(
+            adapter = connected.adapter?.copy(capabilities = EarbudCapabilities(gameModeControl = false)),
+        ).withFeature(GameModeFeatureState(enabled = true))
+
+        val state = GameModeToggleControlPolicy.render(noCapability)
+        assertFalse(state.enabled)
+        assertNull(GameModeToggleControlPolicy.request(noCapability, checked = true))
+    }
+
+    @Test
+    fun gameModeToggleIsDisabledOutsideLiveSession() {
+        val disconnected = connected.copy(lifecycle = DeviceLifecycle())
+            .withFeature(GameModeFeatureState(enabled = true))
+
+        assertFalse(GameModeToggleControlPolicy.render(disconnected).enabled)
+        assertNull(GameModeToggleControlPolicy.request(disconnected, checked = true))
+    }
+
+    @Test
+    fun gameModeToggleRequestsOnlyOnEdgeTransition() {
+        val on = connected.withFeature(GameModeFeatureState(enabled = true))
+        val off = connected.withFeature(GameModeFeatureState(enabled = false))
+
+        assertEquals(true, GameModeToggleControlPolicy.request(off, checked = true))
+        assertEquals(false, GameModeToggleControlPolicy.request(on, checked = false))
+        assertNull(GameModeToggleControlPolicy.request(on, checked = true))
+        assertNull(GameModeToggleControlPolicy.request(off, checked = false))
+    }
+}

--- a/system-module/src/test/java/dev/hyperears/hook/MiLinkCardAdapterRegistryTest.kt
+++ b/system-module/src/test/java/dev/hyperears/hook/MiLinkCardAdapterRegistryTest.kt
@@ -68,6 +68,10 @@ class MiLinkCardAdapterRegistryTest {
             SonyAmbientOnlyMiLinkCardAdapter,
             MiLinkCardAdapterRegistry.resolve(SonyMiLinkPresentationIds.AMBIENT_ONLY),
         )
+        assertSame(
+            FitClipUltraGameModeMiLinkCardAdapter,
+            MiLinkCardAdapterRegistry.resolve(EdifierMiLinkPresentationIds.GAME_MODE),
+        )
         assertNull(
             MiLinkCardAdapterRegistry.resolve(
                 MiLinkCardPresentationId("unknown-model"),


### PR DESCRIPTION
## Summary

Adds charge-case battery reporting to the Edifier TWS device state and wires the **FitClip Ultra** game-mode capability end-to-end, so HyperEars reads/writes game mode on that model.

## Changes

- **`EdifierWireCodec.kt`**: parse charge-case percent/state from the `0xF2` device-state frame (byte 3 = case %, byte 4 = case state `1=charging / 2=not / 3=offline`, case masked when offline; `caseCharging` derived from state). Also add game-mode set/query helpers (`CMD_GAME_STATE_SET=0x09`, `queryGameState`, `setGameMode`, `parseGameModeState`).
- **`EarbudModel.kt` / `ControlRequest.kt` / `EarbudAdapter.kt`**: add `GameModeFeatureState`, the `gameModeControl` capability, the `SetGameMode` standard request + contract, and thread `gameMode` through `CapabilitiesIdentified` and `onCapabilitiesIdentified`.
- **`EdifierEarbudAdapter.kt`**: enable `gameModeQuery` for the FitClip Ultra, emit `GameModeFeatureState` on `0x08/0x09` responses, and fill `EarbudBattery.case` from the parsed case battery.
- **`BoseEarbudAdapter.kt` / `HonorX5sProAdapter.kt`**: adapt to the wider `onCapabilitiesIdentified` signature and the `SetGameMode` branch.
- **`system-module/AndroidManifest.xml`**: declare `BIND_XPOSED_SERVICE`.

## Verification (on-device, confirmed)

- Case battery is now surfaced through `EarbudBattery.case`; the MiLink `batteryLevels` codec maps it to slot 1 (case), with left/right on slots 2/3 and the case charging flag on slot 4.
- Case percent (70%), left (57%), right (6%), case-charging (`1`) were reproduced through `MiLinkStateCodec.batteryLevels(TWS)`.
