### PR TITLE
fix: present FitClip game mode in MiLink native mode card

### DIFF
--- a/system-module/src/main/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapter.kt
@@ -10,6 +10,9 @@ import android.widget.CompoundButton
 import android.widget.LinearLayout
 import android.widget.Switch
 import android.widget.TextView
+import androidx.core.view.doOnLayout
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import dev.hyperears.integration.EdifierControlRequest
 import dev.hyperears.integration.EdifierGameModeFeatureState
 import dev.hyperears.integration.EdifierMiLinkPresentationIds
@@ -49,6 +52,7 @@ internal object FitClipUltraGameModeMiLinkCardAdapter : MiLinkCardAdapter {
         }
         val background = styleCard.background.independentCopy(root)
             ?: return skipped(address, "volume-card-background-unavailable")
+        val panelHeightReservation = PanelHeightReservation(parent)
 
         val row = LinearLayout(root.context).apply {
             orientation = LinearLayout.HORIZONTAL
@@ -100,11 +104,13 @@ internal object FitClipUltraGameModeMiLinkCardAdapter : MiLinkCardAdapter {
             topMargin = anchorParams?.topMargin ?: 0
         }
         parent.addView(row, anchorIndex, rowParams)
+        panelHeightReservation.attach(row)
 
         return Binding(
             parent = parent,
             row = row,
             toggle = toggle,
+            panelHeightReservation = panelHeightReservation,
             address = address,
             environment = environment,
         ).also { binding ->
@@ -130,6 +136,7 @@ internal object FitClipUltraGameModeMiLinkCardAdapter : MiLinkCardAdapter {
         parent: LinearLayout,
         row: View,
         toggle: CompoundButton,
+        private val panelHeightReservation: PanelHeightReservation,
         private val address: String,
         private val environment: MiLinkCardEnvironment,
     ) : MiLinkCardBinding {
@@ -148,6 +155,7 @@ internal object FitClipUltraGameModeMiLinkCardAdapter : MiLinkCardAdapter {
             val toggle = toggle.get() ?: return
             val projected = FitClipGameModeTogglePolicy.render(state)
             row.visibility = if (state.sessionActive) View.VISIBLE else View.GONE
+            panelHeightReservation.setActive(state.sessionActive)
             rendering = true
             try {
                 toggle.isChecked = projected.checked
@@ -190,10 +198,112 @@ internal object FitClipUltraGameModeMiLinkCardAdapter : MiLinkCardAdapter {
 
         override fun unbind() {
             toggle.get()?.setOnCheckedChangeListener(null)
-            val parent = parent.get() ?: return
-            val row = row.get() ?: return
-            if (row.parent === parent) parent.removeView(row)
+            val parent = parent.get()
+            val row = row.get()
+            if (parent != null && row?.parent === parent) parent.removeView(row)
+            panelHeightReservation.release()
         }
+    }
+
+    /**
+     * Reserves the actual custom-row height in MiLink's explicitly sized headset panel.
+     *
+     * MiLink computes `headsets_control` height from stock capability flags instead of measuring
+     * arbitrary children. A stock ANC card contributes to that calculation; a late CardAdapter
+     * row does not. This reservation observes normal layout callbacks, expands only when visible
+     * content would otherwise be clipped, and restores the host's original layout contract when
+     * the binding is removed. It does not call host methods or depend on obfuscated field names.
+     */
+    private class PanelHeightReservation(
+        panel: LinearLayout,
+    ) {
+        private val panel = WeakReference(panel)
+        private var row: WeakReference<View>? = null
+        private val originalLayoutHeight = panel.layoutParams.height
+        private val originalRenderedHeight = maxOf(panel.height, panel.measuredHeight, 0)
+        private var active = false
+        private var appliedHeight: Int? = null
+        private val layoutListener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+            if (active) ensureHeight()
+        }
+
+        fun attach(row: View) {
+            this.row = WeakReference(row)
+            panel.get()?.addOnLayoutChangeListener(layoutListener)
+            setActive(true)
+        }
+
+        fun setActive(active: Boolean) {
+            if (this.active == active) return
+            this.active = active
+            if (active) scheduleMeasurement() else restoreHeight()
+        }
+
+        fun release() {
+            active = false
+            panel.get()?.removeOnLayoutChangeListener(layoutListener)
+            restoreHeight()
+            row?.clear()
+            row = null
+        }
+
+        private fun scheduleMeasurement() {
+            val row = row?.get() ?: return
+            row.doOnLayout {
+                if (active) ensureHeight()
+            }
+            row.requestLayout()
+            panel.get()?.requestLayout()
+        }
+
+        private fun ensureHeight() {
+            val panel = panel.get() ?: return
+            val row = row?.get()?.takeIf { it.isVisible } ?: return
+            val rowParams = row.layoutParams as? ViewGroup.MarginLayoutParams
+            val reservedHeight = row.measuredHeight +
+                (rowParams?.topMargin ?: 0) +
+                (rowParams?.bottomMargin ?: 0)
+            if (reservedHeight <= 0) {
+                scheduleMeasurement()
+                return
+            }
+            val contentHeight = panel.visibleVerticalContentHeight()
+            val requiredHeight = FitClipPanelLayoutPolicy.requiredHeight(
+                originalPanelHeight = originalRenderedHeight,
+                customRowHeight = reservedHeight,
+                measuredContentHeight = contentHeight,
+                availableHeight = (panel.parent as? View)?.height ?: 0,
+            )
+            if (panel.height >= requiredHeight) return
+            panel.layoutParams = panel.layoutParams.apply { height = requiredHeight }
+            appliedHeight = requiredHeight
+            panel.requestLayout()
+            (panel.parent as? View)?.requestLayout()
+            ModuleLog.debug(
+                COMPONENT,
+                "reserved FitClip Ultra panel height base=$originalRenderedHeight " +
+                    "row=$reservedHeight content=$contentHeight target=$requiredHeight",
+            )
+        }
+
+        private fun restoreHeight() {
+            val panel = panel.get() ?: return
+            if (appliedHeight == null) return
+            panel.layoutParams = panel.layoutParams.apply { height = originalLayoutHeight }
+            panel.requestLayout()
+            (panel.parent as? View)?.requestLayout()
+            appliedHeight = null
+        }
+
+        private fun LinearLayout.visibleVerticalContentHeight(): Int =
+            paddingTop + paddingBottom + (0 until childCount).sumOf { index ->
+                val child = getChildAt(index)
+                if (child.isGone) return@sumOf 0
+                val params = child.layoutParams as? ViewGroup.MarginLayoutParams
+                child.measuredHeight +
+                    (params?.topMargin ?: 0) +
+                    (params?.bottomMargin ?: 0)
+            }
     }
 
     private fun createHostToggle(
@@ -228,6 +338,22 @@ internal object FitClipUltraGameModeMiLinkCardAdapter : MiLinkCardAdapter {
     private const val GAME_MODE_LABEL = "游戏模式"
     private const val ENABLED_ALPHA = 1.0f
     private const val DISABLED_ALPHA = 0.45f
+}
+
+/** Pure sizing policy shared by the Android binding and unit tests. */
+internal object FitClipPanelLayoutPolicy {
+    fun requiredHeight(
+        originalPanelHeight: Int,
+        customRowHeight: Int,
+        measuredContentHeight: Int,
+        availableHeight: Int,
+    ): Int {
+        val required = maxOf(
+            measuredContentHeight.coerceAtLeast(0),
+            originalPanelHeight.coerceAtLeast(0) + customRowHeight.coerceAtLeast(0),
+        )
+        return if (availableHeight > 0) required.coerceAtMost(availableHeight) else required
+    }
 }
 
 /** Pure projection from authoritative device state to the FitClip game-mode control. */

--- a/system-module/src/main/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapter.kt
@@ -1,195 +1,118 @@
 package dev.hyperears.hook
 
 import android.content.Context
-import android.graphics.drawable.Drawable
-import android.util.TypedValue
-import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
-import android.widget.CompoundButton
+import android.widget.ImageView
 import android.widget.LinearLayout
-import android.widget.Switch
 import android.widget.TextView
-import androidx.core.view.doOnLayout
-import androidx.core.view.isGone
-import androidx.core.view.isVisible
 import dev.hyperears.integration.EdifierControlRequest
 import dev.hyperears.integration.EdifierGameModeFeatureState
 import dev.hyperears.integration.EdifierMiLinkPresentationIds
 import dev.hyperears.integration.EarbudState
 import dev.hyperears.integration.MiLinkCardPresentationId
+import dev.hyperears.integration.NoiseMode
 import java.lang.ref.WeakReference
 
 /**
- * Adds FitClip Ultra's protocol-confirmed game mode as a standalone native-style control row.
+ * Presents FitClip Ultra game mode through MiLink's complete stock ANC-card slot.
  *
- * This model has no ANC card, so the extension anchors to MiLink's stable More settings row and
- * takes typography, spacing and background from the adjacent native volume card. It never moves or
- * replaces a host view. If the expected semantic structure is unavailable, binding is skipped and
- * the stock card remains untouched.
+ * The stock section remains the sole owner of dimensions, spacing, clipping and animations. This
+ * adapter temporarily replaces its three mode items with two instances of the same native item
+ * class, labelled Standard mode and Game mode. The original title and items are restored on
+ * unbind. No height override, host method, obfuscated field, or delayed layout mutation is used.
  */
 internal object FitClipUltraGameModeMiLinkCardAdapter : MiLinkCardAdapter {
     override val presentationId: MiLinkCardPresentationId =
         EdifierMiLinkPresentationIds.GAME_MODE
+    override val nativeSurface: MiLinkNativeCardSurface =
+        MiLinkNativeCardSurface.ANC_THREE_STATE
+
+    override fun nativeSurfaceNoiseMode(state: EarbudState): NoiseMode =
+        if (state.features.get<EdifierGameModeFeatureState>()?.enabled == true) {
+            NoiseMode.ANC
+        } else {
+            NoiseMode.OFF
+        }
 
     override fun bind(
         root: View,
         address: String,
         environment: MiLinkCardEnvironment,
     ): MiLinkCardBinding? {
-        val moreSettings = root.findMiLinkView(MORE_SETTINGS_ID)
-            ?: return skipped(address, "more-settings-anchor-missing")
-        val parent = moreSettings.parent as? LinearLayout
-            ?: return skipped(address, "more-settings-parent-not-linear")
-        val anchorIndex = parent.indexOfChild(moreSettings)
-            .takeIf { it > 0 }
-            ?: return skipped(address, "more-settings-position-invalid")
-        val styleCard = parent.getChildAt(anchorIndex - 1)
-        val styleTitle = root.findMiLinkView(VOLUME_TITLE_ID) as? TextView
-            ?: return skipped(address, "volume-title-style-missing")
-        if (!styleTitle.isDescendantOf(styleCard)) {
-            return skipped(address, "volume-title-outside-style-card")
-        }
-        val background = styleCard.background.independentCopy(root)
-            ?: return skipped(address, "volume-card-background-unavailable")
-        val panelHeightReservation = PanelHeightReservation(parent)
+        val host = resolveNativeHost(root)
+            ?: return skipped(address, "native-anc-card-unavailable")
+        val standard = host.createItem(
+            root = root,
+            source = host.standardSource,
+            label = STANDARD_MODE_LABEL,
+        ) ?: return skipped(address, "standard-item-construction-failed")
+        val game = host.createItem(
+            root = root,
+            source = host.gameSource,
+            label = GAME_MODE_LABEL,
+        ) ?: return skipped(address, "game-item-construction-failed")
 
-        val row = LinearLayout(root.context).apply {
-            orientation = LinearLayout.HORIZONTAL
-            gravity = Gravity.CENTER_VERTICAL
-            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
-            this.background = background
-            setPadding(
-                styleCard.paddingLeft,
-                styleCard.paddingTop,
-                styleCard.paddingRight,
-                styleCard.paddingBottom,
-            )
-        }
-        val label = TextView(root.context).apply {
-            text = GAME_MODE_LABEL
-            setTextColor(styleTitle.textColors)
-            setTextSize(TypedValue.COMPLEX_UNIT_PX, styleTitle.textSize)
-            typeface = styleTitle.typeface
-            gravity = Gravity.CENTER_VERTICAL
-            maxLines = 1
-            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-        }
-        val toggle = createHostToggle(root.context, environment.hostClassLoader).apply {
-            contentDescription = GAME_MODE_LABEL
-            isSaveEnabled = false
-        }
-        row.addView(
-            label,
-            LinearLayout.LayoutParams(
-                0,
-                ViewGroup.LayoutParams.MATCH_PARENT,
-                1f,
-            ),
-        )
-        row.addView(
-            toggle,
-            LinearLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-                ViewGroup.LayoutParams.WRAP_CONTENT,
-            ),
-        )
-
-        val styleParams = styleCard.layoutParams
-        val anchorParams = moreSettings.layoutParams as? ViewGroup.MarginLayoutParams
-        val rowParams = LinearLayout.LayoutParams(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            styleParams.height.takeIf { it > 0 } ?: ViewGroup.LayoutParams.WRAP_CONTENT,
-        ).apply {
-            topMargin = anchorParams?.topMargin ?: 0
-        }
-        parent.addView(row, anchorIndex, rowParams)
-        panelHeightReservation.attach(row)
-
-        return Binding(
-            parent = parent,
-            row = row,
-            toggle = toggle,
-            panelHeightReservation = panelHeightReservation,
+        val binding = Binding(
+            host = host,
+            standard = standard,
+            game = game,
             address = address,
             environment = environment,
-        ).also { binding ->
-            binding.bind()
-            ModuleLog.debug(
-                COMPONENT,
-                "bound FitClip Ultra game-mode row anchor=$MORE_SETTINGS_ID " +
-                    "style=$VOLUME_TITLE_ID address=${maskBluetoothAddress(address)}",
-            )
-        }
+        )
+        host.install(standard, game)
+        standard.setOnClickListener { binding.onChoiceClicked(gameMode = false) }
+        game.setOnClickListener { binding.onChoiceClicked(gameMode = true) }
+        ModuleLog.debug(
+            COMPONENT,
+            "bound FitClip native game-mode card layout=${host.generation} " +
+                "address=${maskBluetoothAddress(address)}",
+        )
+        return binding
     }
 
     private fun skipped(address: String, reason: String): MiLinkCardBinding? {
         ModuleLog.debug(
             COMPONENT,
-            "skipped FitClip Ultra game-mode row reason=$reason " +
+            "skipped FitClip native game-mode card reason=$reason " +
                 "address=${maskBluetoothAddress(address)}",
         )
         return null
     }
 
     private class Binding(
-        parent: LinearLayout,
-        row: View,
-        toggle: CompoundButton,
-        private val panelHeightReservation: PanelHeightReservation,
+        private val host: NativeAncHost,
+        standard: View,
+        game: View,
         private val address: String,
         private val environment: MiLinkCardEnvironment,
     ) : MiLinkCardBinding {
-        private val parent = WeakReference(parent)
-        private val row = WeakReference(row)
-        private val toggle = WeakReference(toggle)
-        private var rendering = false
-        private var lastRendered: FitClipGameModeTogglePolicy.ToggleState? = null
-
-        fun bind() {
-            toggle.get()?.setOnCheckedChangeListener(::onToggleChanged)
-        }
+        private val standard = WeakReference(standard)
+        private val game = WeakReference(game)
+        private var lastRendered: FitClipGameModeCardPolicy.CardState? = null
 
         override fun render(state: EarbudState) {
-            val row = row.get() ?: return
-            val toggle = toggle.get() ?: return
-            val projected = FitClipGameModeTogglePolicy.render(state)
-            row.visibility = if (state.sessionActive) View.VISIBLE else View.GONE
-            panelHeightReservation.setActive(state.sessionActive)
-            rendering = true
-            try {
-                toggle.isChecked = projected.checked
-                toggle.isEnabled = projected.enabled
-                row.alpha = if (projected.enabled) ENABLED_ALPHA else DISABLED_ALPHA
-            } finally {
-                rendering = false
-            }
+            val standard = standard.get() ?: return
+            val game = game.get() ?: return
+            val projected = FitClipGameModeCardPolicy.render(state)
+            standard.setNativeChoiceEnabled(projected.enabled)
+            game.setNativeChoiceEnabled(projected.enabled)
+            standard.setSelectedTree(!projected.gameMode)
+            game.setSelectedTree(projected.gameMode)
             if (lastRendered != projected) {
                 lastRendered = projected
                 ModuleLog.debug(
                     COMPONENT,
-                    "rendered FitClip Ultra game-mode enabled=${projected.enabled} " +
-                        "checked=${projected.checked} address=${maskBluetoothAddress(address)}",
+                    "rendered FitClip native game-mode card enabled=${projected.enabled} " +
+                        "game=${projected.gameMode} " +
+                        "address=${maskBluetoothAddress(address)}",
                 )
             }
         }
 
-        private fun onToggleChanged(button: CompoundButton, checked: Boolean) {
-            if (rendering) return
+        fun onChoiceClicked(gameMode: Boolean) {
             val current = environment.stateProvider(address)
-            val authoritative = FitClipGameModeTogglePolicy.render(current)
-            rendering = true
-            try {
-                button.isChecked = authoritative.checked
-            } finally {
-                rendering = false
-            }
-            val requested = FitClipGameModeTogglePolicy.request(current, checked) ?: return
-            ModuleLog.debug(
-                COMPONENT,
-                "requested FitClip Ultra game-mode enabled=$requested " +
-                    "address=${maskBluetoothAddress(address)}",
-            )
+            val requested = FitClipGameModeCardPolicy.request(current, gameMode) ?: return
             environment.controlSender(
                 address,
                 EdifierControlRequest.SetGameMode(requested),
@@ -197,183 +120,217 @@ internal object FitClipUltraGameModeMiLinkCardAdapter : MiLinkCardAdapter {
         }
 
         override fun unbind() {
-            toggle.get()?.setOnCheckedChangeListener(null)
-            val parent = parent.get()
-            val row = row.get()
-            if (parent != null && row?.parent === parent) parent.removeView(row)
-            panelHeightReservation.release()
+            standard.get()?.setOnClickListener(null)
+            game.get()?.setOnClickListener(null)
+            host.restore()
         }
     }
 
-    /**
-     * Reserves the actual custom-row height in MiLink's explicitly sized headset panel.
-     *
-     * MiLink computes `headsets_control` height from stock capability flags instead of measuring
-     * arbitrary children. A stock ANC card contributes to that calculation; a late CardAdapter
-     * row does not. This reservation observes normal layout callbacks, expands only when visible
-     * content would otherwise be clipped, and restores the host's original layout contract when
-     * the binding is removed. It does not call host methods or depend on obfuscated field names.
-     */
-    private class PanelHeightReservation(
-        panel: LinearLayout,
+    private class NativeAncHost(
+        val generation: String,
+        title: TextView,
+        container: LinearLayout,
+        originals: List<View>,
+        val standardSource: View,
+        val gameSource: View,
+        private val itemTextId: String,
+        private val itemIconId: String,
     ) {
-        private val panel = WeakReference(panel)
-        private var row: WeakReference<View>? = null
-        private val originalLayoutHeight = panel.layoutParams.height
-        private val originalRenderedHeight = maxOf(panel.height, panel.measuredHeight, 0)
-        private var active = false
-        private var appliedHeight: Int? = null
-        private val layoutListener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-            if (active) ensureHeight()
-        }
+        private data class OriginalItem(
+            val view: View,
+            val index: Int,
+            val layoutParams: ViewGroup.LayoutParams,
+            val visibility: Int,
+        )
 
-        fun attach(row: View) {
-            this.row = WeakReference(row)
-            panel.get()?.addOnLayoutChangeListener(layoutListener)
-            setActive(true)
-        }
-
-        fun setActive(active: Boolean) {
-            if (this.active == active) return
-            this.active = active
-            if (active) scheduleMeasurement() else restoreHeight()
-        }
-
-        fun release() {
-            active = false
-            panel.get()?.removeOnLayoutChangeListener(layoutListener)
-            restoreHeight()
-            row?.clear()
-            row = null
-        }
-
-        private fun scheduleMeasurement() {
-            val row = row?.get() ?: return
-            row.doOnLayout {
-                if (active) ensureHeight()
-            }
-            row.requestLayout()
-            panel.get()?.requestLayout()
-        }
-
-        private fun ensureHeight() {
-            val panel = panel.get() ?: return
-            val row = row?.get()?.takeIf { it.isVisible } ?: return
-            val rowParams = row.layoutParams as? ViewGroup.MarginLayoutParams
-            val reservedHeight = row.measuredHeight +
-                (rowParams?.topMargin ?: 0) +
-                (rowParams?.bottomMargin ?: 0)
-            if (reservedHeight <= 0) {
-                scheduleMeasurement()
-                return
-            }
-            val contentHeight = panel.visibleVerticalContentHeight()
-            val requiredHeight = FitClipPanelLayoutPolicy.requiredHeight(
-                originalPanelHeight = originalRenderedHeight,
-                customRowHeight = reservedHeight,
-                measuredContentHeight = contentHeight,
-                availableHeight = (panel.parent as? View)?.height ?: 0,
-            )
-            if (panel.height >= requiredHeight) return
-            panel.layoutParams = panel.layoutParams.apply { height = requiredHeight }
-            appliedHeight = requiredHeight
-            panel.requestLayout()
-            (panel.parent as? View)?.requestLayout()
-            ModuleLog.debug(
-                COMPONENT,
-                "reserved FitClip Ultra panel height base=$originalRenderedHeight " +
-                    "row=$reservedHeight content=$contentHeight target=$requiredHeight",
+        private val title = WeakReference(title)
+        private val container = WeakReference(container)
+        private val originalTitle = title.text
+        private val originals = originals.map { item ->
+            OriginalItem(
+                view = item,
+                index = container.indexOfChild(item),
+                layoutParams = item.layoutParams,
+                visibility = item.visibility,
             )
         }
+        private val replacements = mutableListOf<WeakReference<View>>()
 
-        private fun restoreHeight() {
-            val panel = panel.get() ?: return
-            if (appliedHeight == null) return
-            panel.layoutParams = panel.layoutParams.apply { height = originalLayoutHeight }
-            panel.requestLayout()
-            (panel.parent as? View)?.requestLayout()
-            appliedHeight = null
-        }
+        fun createItem(root: View, source: View, label: String): View? = runCatching {
+            val item = source.javaClass
+                .getConstructor(Context::class.java)
+                .newInstance(root.context) as View
+            item.id = source.id
+            item.layoutParams = source.layoutParams.nativeCopy()
+            item.visibility = View.VISIBLE
+            item.isSaveEnabled = false
+            item.contentDescription = label
 
-        private fun LinearLayout.visibleVerticalContentHeight(): Int =
-            paddingTop + paddingBottom + (0 until childCount).sumOf { index ->
-                val child = getChildAt(index)
-                if (child.isGone) return@sumOf 0
-                val params = child.layoutParams as? ViewGroup.MarginLayoutParams
-                child.measuredHeight +
-                    (params?.topMargin ?: 0) +
-                    (params?.bottomMargin ?: 0)
+            val targetText = requireNotNull(item.findMiLinkView(itemTextId) as? TextView) {
+                "native item text unavailable: $itemTextId"
             }
-    }
+            targetText.text = label
+            targetText.contentDescription = label
 
-    private fun createHostToggle(
-        context: Context,
-        hostClassLoader: ClassLoader,
-    ): CompoundButton = runCatching {
-        Class.forName(MIUIX_SLIDING_BUTTON, true, hostClassLoader)
-            .asSubclass(CompoundButton::class.java)
-            .getConstructor(Context::class.java)
-            .newInstance(context)
-    }.getOrElse {
-        @Suppress("DEPRECATION")
-        Switch(context)
-    }
+            val sourceIcon = source.findMiLinkView(itemIconId) as? ImageView
+            val targetIcon = requireNotNull(item.findMiLinkView(itemIconId) as? ImageView) {
+                "native item icon unavailable: $itemIconId"
+            }
+            targetIcon.setImageDrawable(
+                sourceIcon?.drawable?.constantState
+                    ?.newDrawable(root.resources)
+                    ?.mutate()
+                    ?: sourceIcon?.drawable,
+            )
+            item
+        }.onFailure {
+            ModuleLog.warn(COMPONENT, "native game-mode item construction failed", it)
+        }.getOrNull()
 
-    private fun View.isDescendantOf(ancestor: View): Boolean {
-        var current: View? = this
-        while (current != null) {
-            if (current === ancestor) return true
-            current = current.parent as? View
+        fun install(standard: View, game: View) {
+            val title = title.get() ?: return
+            val container = container.get() ?: return
+            title.text = GAME_MODE_LABEL
+            originals.sortedByDescending(OriginalItem::index).forEach { original ->
+                if (original.view.parent === container) container.removeView(original.view)
+            }
+            val insertion = originals.minOfOrNull(OriginalItem::index)
+                ?.coerceIn(0, container.childCount)
+                ?: container.childCount
+            container.addView(standard, insertion)
+            container.addView(game, insertion + 1)
+            replacements += WeakReference(standard)
+            replacements += WeakReference(game)
         }
-        return false
+
+        fun restore() {
+            val title = title.get() ?: return
+            val container = container.get() ?: return
+            replacements.mapNotNull(WeakReference<View>::get).forEach { replacement ->
+                if (replacement.parent === container) container.removeView(replacement)
+            }
+            originals.sortedBy(OriginalItem::index).forEach { original ->
+                if (original.view.parent == null) {
+                    original.view.layoutParams = original.layoutParams
+                    original.view.visibility = original.visibility
+                    container.addView(
+                        original.view,
+                        original.index.coerceIn(0, container.childCount),
+                    )
+                }
+            }
+            title.text = originalTitle
+            replacements.clear()
+        }
     }
 
-    private fun Drawable?.independentCopy(root: View): Drawable? =
-        this?.constantState?.newDrawable(root.resources)?.mutate()
+    private fun resolveNativeHost(root: View): NativeAncHost? =
+        resolveSelectCard(root) ?: resolveOriginalCard(root)
+
+    private fun resolveOriginalCard(root: View): NativeAncHost? {
+        val title = root.findMiLinkView(ORIGINAL_TITLE_ID) as? TextView ?: return null
+        val container = root.findMiLinkView(ORIGINAL_CARD_ID) as? LinearLayout ?: return null
+        val transparency = root.findMiLinkView(ORIGINAL_TRANSPARENCY_ID) ?: return null
+        val noise = root.findMiLinkView(ORIGINAL_NOISE_ID) ?: return null
+        val off = root.findMiLinkView(ORIGINAL_OFF_ID) ?: return null
+        val items = listOf(transparency, noise, off)
+        if (items.any { item ->
+                item.parent !== container || item.javaClass.name != ORIGINAL_ITEM_CLASS
+            }
+        ) {
+            return null
+        }
+        return NativeAncHost(
+            generation = "original",
+            title = title,
+            container = container,
+            originals = items,
+            standardSource = off,
+            gameSource = noise,
+            itemTextId = ORIGINAL_ITEM_TEXT_ID,
+            itemIconId = ORIGINAL_ITEM_ICON_ID,
+        )
+    }
+
+    private fun resolveSelectCard(root: View): NativeAncHost? {
+        val title = root.findMiLinkView(SELECT_TITLE_ID) as? TextView ?: return null
+        val container = root.findMiLinkView(SELECT_CARD_ID) as? LinearLayout ?: return null
+        if (container.javaClass.name != SELECT_CARD_CLASS || container.childCount != 3) return null
+        val items = (0 until container.childCount).map(container::getChildAt)
+        if (items.any { it.javaClass.name != SELECT_ITEM_CLASS }) return null
+        return NativeAncHost(
+            generation = "select-card",
+            title = title,
+            container = container,
+            originals = items,
+            standardSource = items[2],
+            gameSource = items[1],
+            itemTextId = SELECT_ITEM_TEXT_ID,
+            itemIconId = SELECT_ITEM_ICON_ID,
+        )
+    }
+
+    private fun View.setNativeChoiceEnabled(enabled: Boolean) {
+        isEnabled = enabled
+        isClickable = enabled
+        alpha = if (enabled) ENABLED_ALPHA else DISABLED_ALPHA
+    }
+
+    private fun View.setSelectedTree(selected: Boolean) {
+        isSelected = selected
+        if (this !is ViewGroup) return
+        for (index in 0 until childCount) getChildAt(index).setSelectedTree(selected)
+    }
+
+    private fun ViewGroup.LayoutParams.nativeCopy(): ViewGroup.LayoutParams = when (this) {
+        is LinearLayout.LayoutParams -> LinearLayout.LayoutParams(this)
+        is ViewGroup.MarginLayoutParams -> ViewGroup.MarginLayoutParams(this)
+        else -> ViewGroup.LayoutParams(this)
+    }
 
     private const val COMPONENT = "MiLinkUi"
-    private const val MORE_SETTINGS_ID = "headset_more_settings"
-    private const val VOLUME_TITLE_ID = "volume_title"
-    private const val MIUIX_SLIDING_BUTTON = "miuix.slidingwidget.widget.SlidingButton"
     private const val GAME_MODE_LABEL = "游戏模式"
+    private const val STANDARD_MODE_LABEL = "标准模式"
     private const val ENABLED_ALPHA = 1.0f
     private const val DISABLED_ALPHA = 0.45f
+
+    private const val ORIGINAL_TITLE_ID = "anc_card_title"
+    private const val ORIGINAL_CARD_ID = "anc_card"
+    private const val ORIGINAL_TRANSPARENCY_ID = "anc_clear"
+    private const val ORIGINAL_NOISE_ID = "anc_noise_cancel"
+    private const val ORIGINAL_OFF_ID = "anc_off"
+    private const val ORIGINAL_ITEM_TEXT_ID = "anc_title"
+    private const val ORIGINAL_ITEM_ICON_ID = "anc_icon"
+    private const val ORIGINAL_ITEM_CLASS =
+        "com.miui.circulate.world.headset.ui.HeadsetControlAncItemView"
+
+    private const val SELECT_TITLE_ID = "anc_card_text"
+    private const val SELECT_CARD_ID = "anc_select_card"
+    private const val SELECT_ITEM_TEXT_ID = "tools_text"
+    private const val SELECT_ITEM_ICON_ID = "tools_icon"
+    private const val SELECT_CARD_CLASS =
+        "com.miui.circulate.world.headset.ui.HeadsetSelectCardView"
+    private const val SELECT_ITEM_CLASS =
+        "com.miui.circulate.world.headset.ui.HeadsetSelectItemView"
 }
 
-/** Pure sizing policy shared by the Android binding and unit tests. */
-internal object FitClipPanelLayoutPolicy {
-    fun requiredHeight(
-        originalPanelHeight: Int,
-        customRowHeight: Int,
-        measuredContentHeight: Int,
-        availableHeight: Int,
-    ): Int {
-        val required = maxOf(
-            measuredContentHeight.coerceAtLeast(0),
-            originalPanelHeight.coerceAtLeast(0) + customRowHeight.coerceAtLeast(0),
-        )
-        return if (availableHeight > 0) required.coerceAtMost(availableHeight) else required
-    }
-}
-
-/** Pure projection from authoritative device state to the FitClip game-mode control. */
-internal object FitClipGameModeTogglePolicy {
-    data class ToggleState(
-        val checked: Boolean,
+internal object FitClipGameModeCardPolicy {
+    data class CardState(
+        val gameMode: Boolean,
         val enabled: Boolean,
     )
 
-    fun render(state: EarbudState): ToggleState {
+    fun render(state: EarbudState): CardState {
         val feature = state.features.get<EdifierGameModeFeatureState>()
-        return ToggleState(
-            checked = feature?.enabled == true,
+        return CardState(
+            gameMode = feature?.enabled == true,
             enabled = state.sessionActive && state.connected && feature != null,
         )
     }
 
-    fun request(state: EarbudState, checked: Boolean): Boolean? {
+    fun request(state: EarbudState, gameMode: Boolean): Boolean? {
         val current = render(state)
-        if (!current.enabled || current.checked == checked) return null
-        return checked
+        if (!current.enabled || current.gameMode == gameMode) return null
+        return gameMode
     }
 }

--- a/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
@@ -18,6 +18,12 @@ import dev.hyperears.integration.NoiseMode
 internal interface MiLinkCardAdapter {
     val presentationId: MiLinkCardPresentationId
 
+    /** Stock MiLink section required as the presentation's visual and sizing carrier. */
+    val nativeSurface: MiLinkNativeCardSurface get() = MiLinkNativeCardSurface.NONE
+
+    /** State projected only into the stock carrier while the concrete CardAdapter owns its UI. */
+    fun nativeSurfaceNoiseMode(state: EarbudState): NoiseMode? = null
+
     /**
      * Projects a model-specific mode onto MiLink's native three-state controller.
      *
@@ -35,6 +41,11 @@ internal interface MiLinkCardAdapter {
         address: String,
         environment: MiLinkCardEnvironment,
     ): MiLinkCardBinding?
+}
+
+internal enum class MiLinkNativeCardSurface {
+    NONE,
+    ANC_THREE_STATE,
 }
 
 internal fun interface MiLinkCardBinding {

--- a/system-module/src/main/java/dev/hyperears/hook/MiLinkServiceHook.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/MiLinkServiceHook.kt
@@ -110,11 +110,7 @@ internal class MiLinkServiceHook : HookContext() {
                 }
             }
             hookBluetoothDeviceResult(className, "getAncState") { device, adapter ->
-                if (adapter.capabilities.noiseControl) {
-                    nativeAncState(stateFor(device))
-                } else {
-                    NO_ANC_STATE
-                }
+                nativeAncStateForSurface(stateFor(device), adapter)
             }
             hookBluetoothDeviceResult(className, "getDeviceRunInfo") { _, _ -> 0 }
             hookBluetoothDeviceResult(className, "getWearStatus") { _, adapter ->
@@ -400,11 +396,7 @@ internal class MiLinkServiceHook : HookContext() {
             "com.miui.headset.runtime.AncBatteryController",
             "getAncState",
         ) { device, adapter ->
-            if (adapter.capabilities.noiseControl) {
-                nativeAncState(stateFor(device))
-            } else {
-                NO_ANC_STATE
-            }
+            nativeAncStateForSurface(stateFor(device), adapter)
         }
         hookBluetoothDeviceResult(
             "com.miui.headset.runtime.AncBatteryController",
@@ -417,7 +409,9 @@ internal class MiLinkServiceHook : HookContext() {
             "com.miui.headset.runtime.AncBatteryController",
             "getSwitchState",
         ) { address ->
-            if (adapterForAddress(address)?.capabilities?.noiseControl == true) 1 else 0
+            adapterForAddress(address)
+                ?.let(::supportsNativeAncSurface)
+                ?.let { supported -> if (supported) 1 else 0 }
         }
 
         runCatching {
@@ -472,26 +466,20 @@ internal class MiLinkServiceHook : HookContext() {
         }
         hookHeadsetInfo("getMode") { info ->
             val state = activeStateForHeadsetInfo(info) ?: return@hookHeadsetInfo null
-            adapterIdentity(state)?.let { adapter ->
-                if (adapter.capabilities.noiseControl) nativeAncState(state) else NO_ANC_STATE
-            }
+            adapterIdentity(state)?.let { adapter -> nativeAncStateForSurface(state, adapter) }
         }
         hookHeadsetInfo("component5") { info ->
             val state = activeStateForHeadsetInfo(info) ?: return@hookHeadsetInfo null
-            adapterIdentity(state)?.let { adapter ->
-                if (adapter.capabilities.noiseControl) nativeAncState(state) else NO_ANC_STATE
-            }
+            adapterIdentity(state)?.let { adapter -> nativeAncStateForSurface(state, adapter) }
         }
         hookHeadsetInfo("getSwitchState") { info ->
             adapterForHeadsetInfo(info)
-                ?.capabilities
-                ?.noiseControl
+                ?.let(::supportsNativeAncSurface)
                 ?.let { supported -> if (supported) 1 else 0 }
         }
         hookHeadsetInfo("component8") { info ->
             adapterForHeadsetInfo(info)
-                ?.capabilities
-                ?.noiseControl
+                ?.let(::supportsNativeAncSurface)
                 ?.let { supported -> if (supported) 1 else 0 }
         }
     }
@@ -699,6 +687,10 @@ internal class MiLinkServiceHook : HookContext() {
                     val address = args.firstOrNull() as? String ?: return@hookBefore
                     val adapter = adapterForAddress(address) ?: return@hookBefore
                     result = when {
+                        nativeCardAdapter(adapter)?.nativeSurface ==
+                            MiLinkNativeCardSurface.ANC_THREE_STATE ->
+                            MILINK_RAW_ANC_ALL_MODES
+
                         !adapter.capabilities.noiseControl -> NO_ANC_CAPABILITY
                         NoiseMode.TRANSPARENCY in adapter.supportedNoiseModes ->
                             MILINK_RAW_ANC_ALL_MODES
@@ -1105,7 +1097,9 @@ internal class MiLinkServiceHook : HookContext() {
         val propertyListeners = propertyChangeListeners()
         if (owners.isEmpty() && propertyListeners.isEmpty()) return
 
-        val capabilities = adapterIdentity(snapshot)?.capabilities ?: return
+        val adapter = adapterIdentity(snapshot) ?: return
+        val capabilities = adapter.capabilities
+        val previousAdapter = adapterIdentity(previous)
         val identityChanged =
             previous.modelId != snapshot.modelId ||
                 previous.address != snapshot.address
@@ -1114,9 +1108,25 @@ internal class MiLinkServiceHook : HookContext() {
         val batteryChanged =
             capabilities.battery &&
                 (identityChanged || adapterChanged || previous.battery != snapshot.battery)
+        val previousAncSurface = previousAdapter?.let(::supportsNativeAncSurface) == true
+        val currentAncSurface = supportsNativeAncSurface(adapter)
+        val previousAncState = previousAdapter
+            ?.takeIf { previousAncSurface }
+            ?.let { nativeAncStateForSurface(previous, it) }
+            ?: NO_ANC_STATE
+        val currentAncState = if (currentAncSurface) {
+            nativeAncStateForSurface(snapshot, adapter)
+        } else {
+            NO_ANC_STATE
+        }
         val ancChanged =
-            capabilities.noiseControl &&
-                (identityChanged || adapterChanged || previous.noiseMode != snapshot.noiseMode)
+            (previousAncSurface || currentAncSurface) &&
+                (
+                    identityChanged ||
+                        adapterChanged ||
+                        previousAncSurface != currentAncSurface ||
+                        previousAncState != currentAncState
+                )
         if (!adapterChanged && !connectionChanged && !batteryChanged && !ancChanged) return
 
         val address = snapshot.address ?: return
@@ -1140,7 +1150,7 @@ internal class MiLinkServiceHook : HookContext() {
         )
 
         val battery = batteryLevelsFor(snapshot)?.toIntArray() ?: return
-        val anc = nativeAncState(snapshot)
+        val anc = currentAncState
         val deviceId = adapterIdentity(snapshot)
             ?.let(MiLinkCarrierIdentity::deviceId)
             ?: return
@@ -1232,6 +1242,25 @@ internal class MiLinkServiceHook : HookContext() {
             projectedMode?.let { state.withFeature(NoiseModeFeatureState(it)) } ?: state,
         )
     }
+
+    private fun nativeAncStateForSurface(
+        state: EarbudState,
+        adapter: AdapterSnapshot,
+    ): Int {
+        if (adapter.capabilities.noiseControl) return nativeAncState(state)
+        val mode = nativeCardAdapter(adapter)
+            ?.takeIf { it.nativeSurface == MiLinkNativeCardSurface.ANC_THREE_STATE }
+            ?.nativeSurfaceNoiseMode(state)
+            ?: return NO_ANC_STATE
+        return MiLinkStateCodec.ancState(state.withFeature(NoiseModeFeatureState(mode)))
+    }
+
+    private fun supportsNativeAncSurface(adapter: AdapterSnapshot): Boolean =
+        adapter.capabilities.noiseControl ||
+            nativeCardAdapter(adapter)?.nativeSurface == MiLinkNativeCardSurface.ANC_THREE_STATE
+
+    private fun nativeCardAdapter(adapter: AdapterSnapshot): MiLinkCardAdapter? =
+        adapter.presentationId?.let(MiLinkCardAdapterRegistry::resolve)
 
     private fun requestState() {
         context?.sendBroadcast(

--- a/system-module/src/test/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapterTest.kt
+++ b/system-module/src/test/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapterTest.kt
@@ -15,6 +15,41 @@ import org.junit.Test
 
 class FitClipGameModeMiLinkCardAdapterTest {
     @Test
+    fun panelHeightAddsTheMeasuredCustomRowToTheHostBase() {
+        assertEquals(
+            700,
+            FitClipPanelLayoutPolicy.requiredHeight(
+                originalPanelHeight = 600,
+                customRowHeight = 100,
+                measuredContentHeight = 680,
+                availableHeight = 1_000,
+            ),
+        )
+    }
+
+    @Test
+    fun panelHeightUsesRealContentAndRespectsTheAvailableWindow() {
+        assertEquals(
+            740,
+            FitClipPanelLayoutPolicy.requiredHeight(
+                originalPanelHeight = 600,
+                customRowHeight = 100,
+                measuredContentHeight = 740,
+                availableHeight = 1_000,
+            ),
+        )
+        assertEquals(
+            720,
+            FitClipPanelLayoutPolicy.requiredHeight(
+                originalPanelHeight = 600,
+                customRowHeight = 100,
+                measuredContentHeight = 740,
+                availableHeight = 720,
+            ),
+        )
+    }
+
+    @Test
     fun confirmedFeatureEnablesTheToggleAndProjectsTheReportedValue() {
         val enabled = connectedState(gameMode = true)
         val disabled = connectedState(gameMode = false)

--- a/system-module/src/test/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapterTest.kt
+++ b/system-module/src/test/java/dev/hyperears/hook/FitClipGameModeMiLinkCardAdapterTest.kt
@@ -4,47 +4,32 @@ import dev.hyperears.integration.AdapterRuntimeState
 import dev.hyperears.integration.DeviceLifecycle
 import dev.hyperears.integration.EdifierGameModeFeatureState
 import dev.hyperears.integration.EarbudState
+import dev.hyperears.integration.NoiseMode
 import dev.hyperears.integration.PrivateTransportState
 import dev.hyperears.integration.ProtocolHandshakeState
 import dev.hyperears.integration.SystemProfileState
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class FitClipGameModeMiLinkCardAdapterTest {
     @Test
-    fun panelHeightAddsTheMeasuredCustomRowToTheHostBase() {
+    fun gameModePresentationUsesTheStockThreeStateSurface() {
         assertEquals(
-            700,
-            FitClipPanelLayoutPolicy.requiredHeight(
-                originalPanelHeight = 600,
-                customRowHeight = 100,
-                measuredContentHeight = 680,
-                availableHeight = 1_000,
-            ),
+            MiLinkNativeCardSurface.ANC_THREE_STATE,
+            FitClipUltraGameModeMiLinkCardAdapter.nativeSurface,
         )
-    }
-
-    @Test
-    fun panelHeightUsesRealContentAndRespectsTheAvailableWindow() {
         assertEquals(
-            740,
-            FitClipPanelLayoutPolicy.requiredHeight(
-                originalPanelHeight = 600,
-                customRowHeight = 100,
-                measuredContentHeight = 740,
-                availableHeight = 1_000,
+            NoiseMode.OFF,
+            FitClipUltraGameModeMiLinkCardAdapter.nativeSurfaceNoiseMode(
+                connectedState(gameMode = false),
             ),
         )
         assertEquals(
-            720,
-            FitClipPanelLayoutPolicy.requiredHeight(
-                originalPanelHeight = 600,
-                customRowHeight = 100,
-                measuredContentHeight = 740,
-                availableHeight = 720,
+            NoiseMode.ANC,
+            FitClipUltraGameModeMiLinkCardAdapter.nativeSurfaceNoiseMode(
+                connectedState(gameMode = true),
             ),
         )
     }
@@ -55,12 +40,12 @@ class FitClipGameModeMiLinkCardAdapterTest {
         val disabled = connectedState(gameMode = false)
 
         assertEquals(
-            FitClipGameModeTogglePolicy.ToggleState(checked = true, enabled = true),
-            FitClipGameModeTogglePolicy.render(enabled),
+            FitClipGameModeCardPolicy.CardState(gameMode = true, enabled = true),
+            FitClipGameModeCardPolicy.render(enabled),
         )
         assertEquals(
-            FitClipGameModeTogglePolicy.ToggleState(checked = false, enabled = true),
-            FitClipGameModeTogglePolicy.render(disabled),
+            FitClipGameModeCardPolicy.CardState(gameMode = false, enabled = true),
+            FitClipGameModeCardPolicy.render(disabled),
         )
     }
 
@@ -68,8 +53,8 @@ class FitClipGameModeMiLinkCardAdapterTest {
     fun missingProtocolEvidenceNeverCreatesAnActionableControl() {
         val state = connectedState(gameMode = null)
 
-        assertFalse(FitClipGameModeTogglePolicy.render(state).enabled)
-        assertNull(FitClipGameModeTogglePolicy.request(state, checked = true))
+        assertFalse(FitClipGameModeCardPolicy.render(state).enabled)
+        assertNull(FitClipGameModeCardPolicy.request(state, gameMode = true))
     }
 
     @Test
@@ -79,9 +64,9 @@ class FitClipGameModeMiLinkCardAdapterTest {
             lifecycle = off.lifecycle.copy(systemProfile = SystemProfileState.DISCONNECTED),
         )
 
-        assertEquals(true, FitClipGameModeTogglePolicy.request(off, checked = true))
-        assertNull(FitClipGameModeTogglePolicy.request(off, checked = false))
-        assertNull(FitClipGameModeTogglePolicy.request(disconnected, checked = true))
+        assertEquals(true, FitClipGameModeCardPolicy.request(off, gameMode = true))
+        assertNull(FitClipGameModeCardPolicy.request(off, gameMode = false))
+        assertNull(FitClipGameModeCardPolicy.request(disconnected, gameMode = true))
     }
 
     private fun connectedState(gameMode: Boolean?): EarbudState {


### PR DESCRIPTION
## Summary

Reworks FitClip Ultra's protocol-confirmed game-mode presentation to reuse MiLink's complete native mode-card surface.

- keeps MiLink responsible for the card's outer height, spacing, clipping and animation;
- replaces the native three mode items with two host-native choices: Standard mode and Game mode;
- maps the confirmed `EdifierGameModeFeatureState` to native selection and keeps `0x08` readback / `0x09` control authoritative;
- restores the original title and all original native items on unbind or vendor-control retreat;
- supports both the original ANC-card layout and the HyperOS 4 select-card layout through stable resource and View-class contracts;
- removes the previous panel-height reservation, measured-child summation and layout listeners completely.

The native surface is presentation metadata, not a declaration that FitClip supports ANC. Generic ANC commands remain rejected because the Adapter's real noise capability stays disabled.

## Verification

- local UI probe on HyperOS confirmed the stock card expands correctly and keeps More settings fully visible;
- FitClip presentation policy and Adapter hierarchy tests pass;
- complete `system-module` unit tests pass;
- `lintDebug` passes;
- Release assembly passes.

The validation-only highest-priority UI probe is not included in this branch.