### PR TITLE
fix(edifier): treat single-ear 0% as not-connected null

### DIFF
--- a/protocol-test/src/main/java/dev/hyperears/protocoltest/ProtocolTestViewModel.kt
+++ b/protocol-test/src/main/java/dev/hyperears/protocoltest/ProtocolTestViewModel.kt
@@ -802,7 +802,7 @@ internal class ProtocolTestViewModel(application: Application) : AndroidViewMode
                             rightPercent = battery.rightPercent,
                             casePercent = null,
                         )
-                        summary = "左=${battery.leftPercent}% 右=${battery.rightPercent}% 盒=—"
+                        summary = "左=${battery.leftPercent ?: "—"}% 右=${battery.rightPercent ?: "—"}% 盒=—"
                     }
                 }
                 mutableState.value = mutableState.value.copy(

--- a/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
+++ b/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
@@ -68,8 +68,8 @@ object EdifierWireCodec {
          * out of the public model until their charging/case semantics are independently verified.
          */
         data class TwsComponents(
-            val leftPercent: Int,
-            val rightPercent: Int,
+            val leftPercent: Int?,
+            val rightPercent: Int?,
             val casePercent: Int? = null,
             val caseCharging: Boolean = false,
         ) : BatteryState
@@ -124,8 +124,9 @@ object EdifierWireCodec {
             CMD_DEVICE_STATE_QUERY -> frame.payload
                 .takeIf { it.size >= TWS_COMPONENT_FIELD_COUNT }
                 ?.let { payload ->
-                    val left = payload[TWS_LEFT_BATTERY_OFFSET].decryptPercent() ?: return@let null
-                    val right = payload[TWS_RIGHT_BATTERY_OFFSET].decryptPercent() ?: return@let null
+                    val left = payload[TWS_LEFT_BATTERY_OFFSET].decryptPercent()?.percentOrNull()
+                    val right = payload[TWS_RIGHT_BATTERY_OFFSET].decryptPercent()?.percentOrNull()
+                    if (left == null && right == null) return@let null
                     val caseState = payload.getOrNull(TWS_CASE_STATE_OFFSET)
                         ?.unsigned()?.let { it xor RESPONSE_XOR_KEY }
                     // Verified on-device (FitClip Ultra): byte3 = case percent, byte4 = case
@@ -318,6 +319,9 @@ object EdifierWireCodec {
 
     private fun Byte.decryptPercent(): Int? =
         (unsigned() xor RESPONSE_XOR_KEY).takeIf { it in 0..100 }
+
+    /** TWS component level: 0 means that earbud is not connected, so map it to null (unknown). */
+    private fun Int.percentOrNull(): Int? = takeIf { it in 1..100 }
 
     private const val TWS_COMPONENT_FIELD_COUNT = 3
     private const val TWS_LEFT_BATTERY_OFFSET = 1

--- a/protocol/src/test/java/dev/hyperears/protocol/edifier/EdifierWireCodecTest.kt
+++ b/protocol/src/test/java/dev/hyperears/protocol/edifier/EdifierWireCodecTest.kt
@@ -87,6 +87,23 @@ class EdifierWireCodecTest {
     }
 
     @Test
+    fun `single worn earbud reports percent 0 as not-connected null`() {
+        // Left earbud disconnected (decrypts to 0) should surface as null, right earbud 98%.
+        // payload bytes 1/2 = 0xA5/0xC7 -> decrypt 0x00/0x62 = 0%/98%. Byte 0 metadata=0x03.
+        val frame = EdifierWireCodec.Decoder().offer(
+            hex("BB EC F2 00 06 A6 A5 C7 A5 A6 B4 B0"),
+        ).single()
+
+        assertEquals(
+            EdifierWireCodec.BatteryState.TwsComponents(
+                leftPercent = null,
+                rightPercent = 98,
+            ),
+            EdifierWireCodec.parseBatteryState(frame),
+        )
+    }
+
+    @Test
     fun `Evo Pro F2 metadata byte is never accepted as aggregate battery`() {
         val frame = EdifierWireCodec.Decoder().offer(
             hex("BB EC F2 00 06 A6 C1 C7 A5 A6 B4 CC"),


### PR DESCRIPTION
## Summary

在 FitClip Ultra（及通用 Edifier TWS）适配链路（承接 #59 之后）中，发现**单边佩戴**时未佩戴侧耳机会上报 0%。把 0% 当作真实电量展示会误导用户（看起来「其中一只没电了」，实际是未佩戴未连接）。本修复把 0% 映射为「未知（null）」并相应处理。

## Changes

- **TwsComponents.leftPercent / rightPercent 由 `Int` 改为 `Int?`**：单侧未连接时上报 null 而不是 0。
- **EdifierWireCodec.kt**：新增 `percentOrNull()`，把 0 映射为 null；两侧均为 null 时直接丢弃该帧。
- **ProtocolTestViewModel.kt**：协议测试摘要把缺失/未连接侧渲染为破折号（em dash），而非 0%。
- **EdifierWireCodecTest.kt**：补充单边 0% → null 的单元测试。

## Verification (on-device)

- 单边佩戴时，未连接侧不再显示 0%，而显示未知；已连接侧电量正常。
- 双边佩戴恢复后左右耳电量均正常显示。
- 逻辑与 PR #54 引入的 `case` 电池字段和 #59 的模式卡展示无冲突。
