### PR TITLE
feat: add EDIFIER FitBuds Turbo adapter (per-ear battery, ANC four-mode, game mode)

### DIFF
--- a/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EarbudAdapter.kt
@@ -626,6 +626,7 @@ object EarbudAdapterRegistry {
         add(Registration(edifierGroup, ::EdifierW860NBProAdapter))
         add(Registration(edifierGroup, ::EdifierEvoProAdapter))
         add(Registration(edifierGroup, ::EdifierFitClipUltraAdapter))
+        add(Registration(edifierGroup, ::EdifierFitBudsTurboAdapter))
         add(Registration(edifierGroup, ::EdifierHeadphonesAdapter))
         add(Registration(edifierGroup, ::EdifierEarbudAdapter))
         add(Registration(roseGroup, ::FurinaEndlessAdapter))

--- a/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EdifierEarbudAdapter.kt
@@ -236,6 +236,14 @@ class EdifierFitClipUltraAdapter : EdifierEarbudAdapter() {
 object EdifierMiLinkPresentationIds {
     val FOUR_MODE = MiLinkCardPresentationId("edifier-four-mode")
     val GAME_MODE = MiLinkCardPresentationId("edifier-fitclip-game")
+
+    /**
+     * FitBuds Turbo-specific card: the ANC four-mode card (transparency / ANC / off / wind)
+     * plus a game-mode switch beside the native title. Kept as its own ID so the Turbo adapter
+     * does not share the generic four-mode card and can expose both wind-noise and low-latency
+     * game control on a single MiLink card.
+     */
+    val FITBUDS_TURBO = MiLinkCardPresentationId("edifier-fitbuds-turbo")
 }
 
 enum class EdifierBatteryQuery(val commandIndex: Int) {
@@ -314,6 +322,17 @@ data class EdifierWireConfig(
     ),
     val preferredAncIndex: Int? = null,
     val gameModeQuery: Boolean = false,
+    /**
+     * When true the device answers the Edifier BES protocol with **plaintext** response
+     * payloads (no XOR 0xA5 obfuscation) and expects plaintext set commands.
+     *
+     * Most Edifier headsets (W860NB PRO, Evo Pro, FitClip Ultra) XOR their response payloads with
+     * [EdifierWireCodec.RESPONSE_XOR_KEY] and require set commands to be XOR-obfuscated the same
+     * way. FitBuds Turbo is an exception: its query responses are plaintext and its set commands
+     * are accepted without the XOR transform. Confirmed on-device (2026-09-01) by the ANC query
+     * returning `1B 06` verbatim (EVO_PRO ANC slot + OFF value) which the XOR decode mangles.
+     */
+    val plaintextPayloads: Boolean = false,
 ) {
     init {
         require(batteryQueries.isNotEmpty())
@@ -337,6 +356,9 @@ private class EdifierProtocolSession(
     private var handshakePublished = false
     private var activeAncDialect: EdifierAncDialect? =
         configuration.preferredAncIndex?.let(configuration::dialect)
+
+    /** True when this device requires the XOR 0xA5 obfuscation on responses and set commands. */
+    private val encryptPayloads: Boolean get() = !configuration.plaintextPayloads
 
     override fun initialReadCommands(): List<ByteArray> = buildList {
         addAll(configuration.batteryQueries.map { batteryQueryPacket(it) })
@@ -363,13 +385,19 @@ private class EdifierProtocolSession(
             val dialect = activeAncDialect
             val ancValue = dialect?.writeValues?.get(request.mode)
             if (ancValue != null) {
-                listOf(EdifierWireCodec.setAnc(ancValue = ancValue, ancIndex = dialect.index))
+                listOf(
+                    EdifierWireCodec.setAnc(
+                        ancValue = ancValue,
+                        ancIndex = dialect.index,
+                        encrypt = encryptPayloads,
+                    ),
+                )
             } else {
                 emptyList()
             }
         }
         request is EdifierControlRequest.SetGameMode ->
-            listOf(EdifierWireCodec.setGameMode(request.enabled))
+            listOf(EdifierWireCodec.setGameMode(request.enabled, encrypt = encryptPayloads))
 
         else -> emptyList()
     }
@@ -399,7 +427,7 @@ private class EdifierProtocolSession(
             val acceptsBatteryCommand = configuration.batteryQueries.any {
                 it.commandIndex == frame.commandIndex
             }
-            EdifierWireCodec.parseBatteryState(frame)
+            EdifierWireCodec.parseBatteryState(frame, encrypted = encryptPayloads)
                 ?.takeIf { acceptsBatteryCommand }
                 ?.let { battery ->
                     add(ProtocolEvent.CapabilitiesIdentified(battery = true))
@@ -412,7 +440,7 @@ private class EdifierProtocolSession(
                     return@forEach
                 }
 
-            EdifierWireCodec.parseAncState(frame)?.let { anc ->
+            EdifierWireCodec.parseAncState(frame, encrypted = encryptPayloads)?.let { anc ->
                 val dialect = configuration.dialect(anc.mode) ?: return@let
                 activeAncDialect = dialect
                 val mode = anc.level?.let(dialect.readValues::get)
@@ -441,7 +469,7 @@ private class EdifierProtocolSession(
             }
 
             // Game-mode state from 0x08 query or 0x09 set response
-            EdifierWireCodec.parseGameModeState(frame)?.let { enabled ->
+            EdifierWireCodec.parseGameModeState(frame, encrypted = encryptPayloads)?.let { enabled ->
                 add(
                     ProtocolEvent.FeatureStateChanged(
                         EdifierGameModeFeatureState(enabled),

--- a/integration/src/main/java/dev/hyperears/integration/EdifierFitBudsTurboAdapter.kt
+++ b/integration/src/main/java/dev/hyperears/integration/EdifierFitBudsTurboAdapter.kt
@@ -1,0 +1,96 @@
+package dev.hyperears.integration
+
+/**
+ * Concrete model adapter for Edifier FitBuds Turbo.
+ *
+ * FitBuds Turbo is a 2026 in-ear TWS with -49 dB ANC, wind-noise reduction, five noise modes
+ * and a 45 ms low-latency game mode. It uses the shared Edifier BES SPP service
+ * (`EDF00000-...`), so the standard family wire layer already carries transport discovery.
+ *
+ * Protocol assumptions (family extrapolation from FitClip Ultra / 花再 Evo Pro):
+ *  - Battery is delivered by the TWS device-state command `0xF2` as independent left/right
+ *    levels, projected to a TWS aggregate (same code path as FitClip Ultra and Evo Pro).
+ *  - ANC is probed through the family dialect candidates. The adapter deliberately starts with
+ *    all private capabilities locked: MiLink only exposes noise modes after a legal ANC
+ *    response confirms the correct dialect, so an unknown ANC slot never mis-advertises.
+ *  - Game mode uses the BES `0x08/0x09` low-latency family command.
+ *
+ * NOTE: The battery command (`0xD0` legacy vs `0xF2` device-state) and the exact ANC
+ * dialect / game-mode support MUST be confirmed with an on-device capture before merging
+ * (see docs/patch-NOTES.md). The initial capability gating keeps this adapter safe even if
+ * the guesses are wrong.
+ */
+class EdifierFitBudsTurboAdapter : EdifierEarbudAdapter() {
+    override val id: String = ID
+    override val displayName: String = "Edifier FitBuds Turbo"
+    override val resolution: AdapterResolution = AdapterResolution.EXACT_MATCH
+
+    override val miLinkCardPresentationId: MiLinkCardPresentationId?
+        get() = EdifierMiLinkPresentationIds.FITBUDS_TURBO.takeIf {
+            // FitBuds Turbo is an ANC model with a 45 ms game mode. The dedicated card shows the
+            // ANC four modes (ANC/off/transparency/wind) plus a game-mode switch. It is exposed
+            // once the ANC dialect is protocol-confirmed (wind-noise control implies the four-mode
+            // family) and the game-mode feature has been observed on the wire.
+            effectiveCapabilities().windNoiseControl &&
+                runtimeState().features.get<EdifierGameModeFeatureState>() != null
+        }
+
+    override val featureStateContract: DeviceFeatureStateContract =
+        StandardDeviceFeatureStateContract.extending { _, state ->
+            state is EdifierGameModeFeatureState
+        }
+
+    override val controlRequestContract: ControlRequestContract =
+        StandardControlRequestContract.extending { adapter, request ->
+            request is EdifierControlRequest.SetGameMode &&
+                adapter.runtimeState().features.get<EdifierGameModeFeatureState>() != null
+        }
+
+    override val wireConfig: EdifierWireConfig = EdifierWireConfig(
+        batteryQueries = listOf(EdifierBatteryQuery.DEVICE_STATE),
+        batteryProjection = EdifierBatteryProjection.TWS_AGGREGATE,
+        // FitBuds Turbo supports ANC + transparency + wind. Probe the family dialect candidates
+        // so the exact ANC slot/value mapping is confirmed on-device rather than hard-coded.
+        ancDialects = listOf(
+            EdifierAncDialects.W860_NB_PRO,
+            EdifierAncDialects.EVO_PRO,
+        ),
+        // 45 ms low-latency mode: probe the BES game-mode family command.
+        gameModeQuery = true,
+        // FitBuds Turbo answers the private protocol with PLAINTEXT payloads (no XOR 0xA5) and
+        // accepts plaintext set commands. Confirmed on-device: ANC query returns `1B 06` verbatim.
+        plaintextPayloads = true,
+    )
+
+    override fun controlPolicy(request: ControlRequest): ControlExecutionPolicy =
+        super.controlPolicy(request).let { policy ->
+            when (request) {
+                is EdifierControlRequest.SetGameMode ->
+                    ControlExecutionPolicy(
+                        confirmation = ControlConfirmationPolicy.DEVICE_REPORT,
+                    )
+
+                is StandardControlRequest.SetNoiseMode ->
+                    policy.copy(
+                        confirmation = ControlConfirmationPolicy.PUBLISH_AFTER_WRITE,
+                    )
+
+                else -> policy
+            }
+        }
+
+    override fun matches(identity: EarbudIdentity): Boolean {
+        if (!identity.standardHeadset || identity.nativeSystemEarbud) return false
+        return normalizeDeviceName(identity.deviceName.orEmpty()) in MODEL_NAMES
+    }
+
+    companion object {
+        const val ID = "edifier-fitbuds-turbo"
+
+        /** Normalized Bluetooth names (lowercase, alphanumeric only) that select this model. */
+        private val MODEL_NAMES = setOf(
+            "edifierfitbudsturbo",
+            "fitbudsturbo",
+        )
+    }
+}

--- a/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
+++ b/protocol/src/main/java/dev/hyperears/protocol/edifier/EdifierWireCodec.kt
@@ -89,31 +89,31 @@ object EdifierWireCodec {
     val queryVersion: ByteArray = packet(CMD_VERSION_QUERY)
     val queryGameState: ByteArray = packet(CMD_GAME_STATE_QUERY)
 
-    fun setAnc(ancValue: Int, ancIndex: Int = ANC_INDEX): ByteArray =
+    fun setAnc(ancValue: Int, ancIndex: Int = ANC_INDEX, encrypt: Boolean = true): ByteArray =
         packet(
             CMD_ANC_SET,
             byteArrayOf(ancIndex.toByte(), ancValue.toByte()),
-            xorKey = RESPONSE_XOR_KEY,
+            xorKey = if (encrypt) RESPONSE_XOR_KEY else 0,
         )
 
     /** Game mode: payload is a single byte 1=on / 0=off, XOR-encrypted like ANC. */
-    fun setGameMode(enabled: Boolean): ByteArray =
+    fun setGameMode(enabled: Boolean, encrypt: Boolean = true): ByteArray =
         packet(
             CMD_GAME_STATE_SET,
             byteArrayOf(if (enabled) 0x01 else 0x00),
-            xorKey = RESPONSE_XOR_KEY,
+            xorKey = if (encrypt) RESPONSE_XOR_KEY else 0,
         )
 
     // ── Parsing ──
 
-    /** Parses command-specific battery telemetry encrypted with [RESPONSE_XOR_KEY]. */
-    fun parseBatteryState(frame: Frame): BatteryState? {
+    /** Parses command-specific battery telemetry. Set [encrypted] = false for plaintext-payload devices. */
+    fun parseBatteryState(frame: Frame, encrypted: Boolean = true): BatteryState? {
         if (!isProtocolResponse(frame)) return null
         return when (frame.commandIndex) {
             // Verified: BB EC D0 00 01 99 11 -> 99 xor A5 = 3C = 60%.
             CMD_BATTERY_QUERY -> frame.payload
                 .singleOrNull()
-                ?.decryptPercent()
+                ?.let { if (encrypted) it.decryptPercent() else it.unsigned().takeIf { p -> p in 0..100 } }
                 ?.let { BatteryState.Aggregate(it) }
 
             // Captured Evo Pro response:
@@ -124,16 +124,16 @@ object EdifierWireCodec {
             CMD_DEVICE_STATE_QUERY -> frame.payload
                 .takeIf { it.size >= TWS_COMPONENT_FIELD_COUNT }
                 ?.let { payload ->
-                    val left = payload[TWS_LEFT_BATTERY_OFFSET].decryptPercent() ?: return@let null
-                    val right = payload[TWS_RIGHT_BATTERY_OFFSET].decryptPercent() ?: return@let null
-                    val caseState = payload.getOrNull(TWS_CASE_STATE_OFFSET)
-                        ?.unsigned()?.let { it xor RESPONSE_XOR_KEY }
+                    val left = batteryByte(payload, TWS_LEFT_BATTERY_OFFSET, encrypted) ?: return@let null
+                    val right = batteryByte(payload, TWS_RIGHT_BATTERY_OFFSET, encrypted) ?: return@let null
+                    val caseState = payload.getOrNull(TWS_CASE_STATE_OFFSET)?.unsigned()
+                        ?.let { if (encrypted) it xor RESPONSE_XOR_KEY else it }
                     // Verified on-device (FitClip Ultra): byte3 = case percent, byte4 = case
                     // state (1=charging, 2=not, 3=offline). Case omitted when state is offline.
                     val casePercent = when (caseState) {
                         TWS_CASE_STATE_CHARGING,
                         TWS_CASE_STATE_NOT_CHARGING,
-                        -> payload.getOrNull(TWS_CASE_BATTERY_OFFSET)?.decryptPercent()
+                        -> batteryByte(payload, TWS_CASE_BATTERY_OFFSET, encrypted)
 
                         TWS_CASE_STATE_OFFLINE -> null
                         else -> null
@@ -150,29 +150,40 @@ object EdifierWireCodec {
         }
     }
 
+    private fun batteryByte(payload: ByteArray, offset: Int, encrypted: Boolean): Int? =
+        payload.getOrNull(offset)?.unsigned()?.let { value ->
+            if (encrypted) value xor RESPONSE_XOR_KEY else value
+        }?.takeIf { it in 0..100 }
+
     /**
-     * Parse an ANC response. Response payload is XOR-encrypted with [RESPONSE_XOR_KEY].
+     * Parse an ANC response. Response payload is XOR-encrypted with [RESPONSE_XOR_KEY] on
+     * most devices.
      * Verified: `BB EC CC 00 02 B5 A0 CA` -> payload=[0xB5,0xA0] -> XOR 0xA5 = [0x10, 0x05]
      * -> ancIndex=16, ancValue=5 (NC off).
+     *
+     * Some devices (e.g. FitBuds Turbo) answer the ANC query with a **plaintext** payload
+     * (`[ancIndex][ancValue]` directly, e.g. `1B 06`). Set [encrypted] = false for those so the
+     * payload is read verbatim instead of being mangled by the XOR transform.
      */
-    fun parseAncState(frame: Frame): AncState? {
+    fun parseAncState(frame: Frame, encrypted: Boolean = true): AncState? {
         if (!isProtocolResponse(frame)) return null
         if (frame.commandIndex != CMD_ANC_QUERY && frame.commandIndex != CMD_ANC_SET) {
             return null
         }
         if (frame.payload.isEmpty()) return null
-        val mode = (frame.payload[0].unsigned() xor RESPONSE_XOR_KEY)
-        val level = frame.payload.getOrNull(1)?.unsigned()?.let { it xor RESPONSE_XOR_KEY }
+        val mode = frame.payload[0].unsigned().let { if (encrypted) it xor RESPONSE_XOR_KEY else it }
+        val level = frame.payload.getOrNull(1)?.unsigned()?.let { if (encrypted) it xor RESPONSE_XOR_KEY else it }
         return AncState(mode = mode, level = level)
     }
 
     /** Parses game-mode state from a 0x08 query or 0x09 set response (1=on, 0=off). */
-    fun parseGameModeState(frame: Frame): Boolean? {
+    fun parseGameModeState(frame: Frame, encrypted: Boolean = true): Boolean? {
         if (!isProtocolResponse(frame)) return null
         if (frame.commandIndex != CMD_GAME_STATE_QUERY && frame.commandIndex != CMD_GAME_STATE_SET) {
             return null
         }
-        val value = frame.payload.firstOrNull()?.unsigned()?.let { it xor RESPONSE_XOR_KEY } ?: return null
+        val value = frame.payload.firstOrNull()?.unsigned()
+            ?.let { if (encrypted) it xor RESPONSE_XOR_KEY else it } ?: return null
         return when (value) {
             0 -> false
             1 -> true

--- a/protocol/src/test/java/dev/hyperears/protocol/edifier/EdifierWireCodecTest.kt
+++ b/protocol/src/test/java/dev/hyperears/protocol/edifier/EdifierWireCodecTest.kt
@@ -108,6 +108,53 @@ class EdifierWireCodecTest {
         assertEquals(6, anc.level)
     }
 
+    // ── Plaintext payload devices (e.g. FitBuds Turbo) ──
+
+    /** FitBuds Turbo ANC response is PLAINTEXT: BB EC CC 00 02 1B 06 -> slot 0x1B, level 6. */
+    @Test
+    fun `parse plaintext ANC response without XOR gives Evo Pro slot`() {
+        val frame = EdifierWireCodec.Decoder().offer(
+            hex("BB EC CC 00 02 1B 06 96"),
+        ).single()
+
+        // Default path assumes XOR-encrypted -> mangled mode, must NOT resolve to 0x1B.
+        val encrypted = EdifierWireCodec.parseAncState(frame)
+        assertNull(encrypted?.let { if (it.mode == 0x1B) it else null })
+
+        // Plaintext path reads the payload verbatim -> slot 0x1B, level 6 (OFF).
+        val plain = requireNotNull(EdifierWireCodec.parseAncState(frame, encrypted = false))
+        assertEquals(0x1B, plain.mode)
+        assertEquals(6, plain.level)
+    }
+
+    /** FitBuds Turbo F2 battery response is PLAINTEXT: 03 64 64 00 03 11 -> L/R 100%. */
+    @Test
+    fun `parse plaintext F2 response gives independent ear batteries`() {
+        val frame = EdifierWireCodec.Decoder().offer(
+            hex("BB EC F2 00 06 03 64 64 00 03 11 7E"),
+        ).single()
+
+        val plain = requireNotNull(EdifierWireCodec.parseBatteryState(frame, encrypted = false))
+        assertEquals(
+            EdifierWireCodec.BatteryState.TwsComponents(leftPercent = 100, rightPercent = 100),
+            plain,
+        )
+    }
+
+    /** Plaintext set commands must NOT be XOR-obfuscated on the wire. */
+    @Test
+    fun `plaintext ANC set stays unencrypted`() {
+        // EVO_PRO slot 0x1B, deep NC value 1 -> plaintext payload 1B 01. CRC=0x75.
+        val expected = byteArrayOf(
+            0xAA.toByte(), 0xEC.toByte(), 0xC1.toByte(), 0x00.toByte(), 0x02.toByte(),
+            0x1B.toByte(), 0x01.toByte(), 0x75.toByte(),
+        )
+        assertEquals(
+            expected.toHex(),
+            EdifierWireCodec.setAnc(1, ancIndex = 0x1B, encrypt = false).toHex(),
+        )
+    }
+
     // ── Send framing ──
 
     /** Battery query: AA EC D0 00 00 66 */

--- a/system-module/src/main/java/dev/hyperears/hook/EdifierFitBudsTurboMiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/EdifierFitBudsTurboMiLinkCardAdapter.kt
@@ -1,0 +1,581 @@
+package dev.hyperears.hook
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CompoundButton
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.Switch
+import android.widget.TextView
+import androidx.core.view.isVisible
+import dev.hyperears.integration.EarbudState
+import dev.hyperears.integration.EdifierControlRequest
+import dev.hyperears.integration.EdifierGameModeFeatureState
+import dev.hyperears.integration.EdifierMiLinkPresentationIds
+import dev.hyperears.integration.MiLinkCardPresentationId
+import dev.hyperears.integration.NoiseMode
+import dev.hyperears.integration.StandardControlRequest
+import java.lang.ref.WeakReference
+
+/**
+ * FitBuds Turbo-specific MiLink card: the ANC four-mode card plus a game-mode switch.
+ *
+ * Transparency, ANC and Off remain entirely native MiLink actions. A WIND switch sits beside the
+ * native ANC title (same accessory contract as the generic [WindNoiseToggleMiLinkCardAdapter]),
+ * and an additional game-mode switch is rendered next to it. Game mode is delivered through the
+ * Edifier low-latency request [EdifierControlRequest.SetGameMode], exactly as the FitClip Ultra
+ * game-mode card does.
+ *
+ * The stock section remains the sole owner of dimensions, spacing, clipping and animations; this
+ * adapter only adds two accessory switches beside the native title. Original layout is restored on
+ * unbind. No height override, host method, obfuscated field, or delayed layout mutation is used.
+ */
+internal object EdifierFitBudsTurboMiLinkCardAdapter : MiLinkCardAdapter {
+    override val presentationId: MiLinkCardPresentationId =
+        EdifierMiLinkPresentationIds.FITBUDS_TURBO
+    override val nativeSurface: MiLinkNativeCardSurface =
+        MiLinkNativeCardSurface.ANC_THREE_STATE
+
+    override fun nativeSurfaceNoiseMode(state: EarbudState): NoiseMode? =
+        state.noiseMode
+
+    override fun bind(
+        root: View,
+        address: String,
+        environment: MiLinkCardEnvironment,
+    ): MiLinkCardBinding? {
+        resolveTitleAncCard(root)?.let { host ->
+            return bindTitleAccessory(root, host, address, environment)
+        }
+        resolveEmbeddedAncCard(root)?.let { host ->
+            return bindEmbeddedAccessory(root, host, address, environment)
+        }
+        return null
+    }
+
+    private fun bindTitleAccessory(
+        root: View,
+        host: TitleAncCard,
+        address: String,
+        environment: MiLinkCardEnvironment,
+    ): MiLinkCardBinding? {
+        val title = host.title
+        val ancCard = host.container
+        val parent = title.parent as? ViewGroup ?: return null
+        val index = parent.indexOfChild(title).takeIf { it >= 0 } ?: return null
+        val originalParams = title.layoutParams
+        val originalWidth = originalParams.width
+
+        parent.removeViewAt(index)
+        val wrapper = FrameLayout(root.context).apply {
+            layoutParams = originalParams.apply {
+                width = ViewGroup.LayoutParams.MATCH_PARENT
+            }
+        }
+        title.layoutParams = FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT,
+        )
+        wrapper.addView(title)
+
+        val accessory = LinearLayout(root.context).apply {
+            gravity = Gravity.CENTER_VERTICAL
+            orientation = LinearLayout.HORIZONTAL
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+        }
+        val windLabel = accessoryLabel(root.context, title, WIND_LABEL)
+        val windToggle = createHostToggle(root.context, environment.hostClassLoader).apply {
+            contentDescription = WIND_LABEL
+            isSaveEnabled = false
+        }
+        accessory.addView(windLabel)
+        accessory.addView(windToggle)
+
+        val gameLabel = accessoryLabel(
+            root.context,
+            title,
+            GAME_MODE_LABEL,
+            startPaddingDp = GAME_LABEL_START_PADDING_DP,
+        )
+        val gameToggle = createHostToggle(root.context, environment.hostClassLoader).apply {
+            contentDescription = GAME_MODE_LABEL
+            isSaveEnabled = false
+        }
+        accessory.addView(gameLabel)
+        accessory.addView(gameToggle)
+
+        wrapper.addView(
+            accessory,
+            FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                Gravity.END or Gravity.CENTER_VERTICAL,
+            ),
+        )
+        parent.addView(wrapper, index)
+
+        val controller = FitBudsTurboController(windToggle, gameToggle, address, environment)
+        return TitleBinding(
+            parent = parent,
+            originalIndex = index,
+            originalLayoutParams = originalParams,
+            originalWidth = originalWidth,
+            wrapper = wrapper,
+            title = title,
+            ancCard = ancCard,
+            accessory = accessory,
+            controller = controller,
+        ).also {
+            controller.bind()
+            ModuleLog.debug(
+                COMPONENT,
+                "bound FitBuds Turbo wind+game switches layout=${host.generation.logName} " +
+                    "address=${maskBluetoothAddress(address)}",
+            )
+        }
+    }
+
+    private fun bindEmbeddedAccessory(
+        root: View,
+        host: EmbeddedAncCard,
+        address: String,
+        environment: MiLinkCardEnvironment,
+    ): MiLinkCardBinding? {
+        val parent = host.container.parent as? ViewGroup ?: return null
+        val originalIndex = parent.indexOfChild(host.container).takeIf { it >= 0 } ?: return null
+        val originalLayoutParams = host.container.layoutParams
+        val originalBackground = host.container.background
+
+        val accessory = LinearLayout(root.context).apply {
+            gravity = Gravity.CENTER_VERTICAL
+            orientation = LinearLayout.HORIZONTAL
+            importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+            setPadding(
+                root.context.dp(EMBEDDED_HEADER_HORIZONTAL_PADDING_DP),
+                0,
+                root.context.dp(EMBEDDED_HEADER_HORIZONTAL_PADDING_DP),
+                0,
+            )
+        }
+        val windToggle = createHostToggle(root.context, environment.hostClassLoader).apply {
+            contentDescription = WIND_LABEL
+            isSaveEnabled = false
+        }
+        val windLabel = embeddedLabel(root.context, host, WIND_LABEL)
+        accessory.addView(
+            windLabel,
+            LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                1f,
+            ),
+        )
+        accessory.addView(
+            windToggle,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            ),
+        )
+
+        val gameToggle = createHostToggle(root.context, environment.hostClassLoader).apply {
+            contentDescription = GAME_MODE_LABEL
+            isSaveEnabled = false
+        }
+        val gameLabel = embeddedLabel(root.context, host, GAME_MODE_LABEL)
+        accessory.addView(
+            gameLabel,
+            LinearLayout.LayoutParams(
+                0,
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                1f,
+            ),
+        )
+        accessory.addView(
+            gameToggle,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+            ),
+        )
+
+        val wrapper = LinearLayout(root.context).apply {
+            orientation = LinearLayout.VERTICAL
+            layoutParams = originalLayoutParams
+            background = originalBackground
+        }
+        parent.removeViewAt(originalIndex)
+        host.container.background = null
+        host.container.layoutParams = LinearLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        )
+        wrapper.addView(
+            accessory,
+            LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                root.context.dp(EMBEDDED_HEADER_HEIGHT_DP),
+            ),
+        )
+        wrapper.addView(host.container)
+        parent.addView(wrapper, originalIndex)
+
+        val controller = FitBudsTurboController(windToggle, gameToggle, address, environment)
+        return EmbeddedBinding(
+            parent = parent,
+            originalIndex = originalIndex,
+            originalLayoutParams = originalLayoutParams,
+            originalBackground = originalBackground,
+            wrapper = wrapper,
+            ancCard = host.container,
+            accessory = accessory,
+            controller = controller,
+        ).also {
+            controller.bind()
+            ModuleLog.debug(
+                COMPONENT,
+                "bound FitBuds Turbo wind+game switches layout=embedded-original " +
+                    "address=${maskBluetoothAddress(address)}",
+            )
+        }
+    }
+
+    private fun accessoryLabel(
+        context: Context,
+        styleSource: TextView,
+        text: String,
+        startPaddingDp: Int = 0,
+        endPaddingDp: Int = LABEL_END_PADDING_DP,
+    ): TextView = TextView(context).apply {
+        this.text = text
+        setTextColor(styleSource.currentTextColor)
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, styleSource.textSize)
+        typeface = styleSource.typeface
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+        setPadding(
+            context.dp(startPaddingDp),
+            0,
+            context.dp(endPaddingDp),
+            0,
+        )
+    }
+
+    private fun embeddedLabel(
+        context: Context,
+        host: EmbeddedAncCard,
+        text: String,
+    ): TextView = TextView(context).apply {
+        this.text = text
+        setTextColor(host.styleSource.textColors)
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, host.styleSource.textSize)
+        typeface = host.styleSource.typeface
+        gravity = Gravity.CENTER_VERTICAL
+        maxLines = 1
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+    }
+
+    private class TitleBinding(
+        parent: ViewGroup,
+        private val originalIndex: Int,
+        private val originalLayoutParams: ViewGroup.LayoutParams,
+        private val originalWidth: Int,
+        wrapper: View,
+        title: View,
+        ancCard: View,
+        accessory: View,
+        private val controller: FitBudsTurboController,
+    ) : MiLinkCardBinding {
+        private val parent = WeakReference(parent)
+        private val wrapper = WeakReference(wrapper)
+        private val title = WeakReference(title)
+        private val ancCard = WeakReference(ancCard)
+        private val accessory = WeakReference(accessory)
+
+        override fun render(state: EarbudState) {
+            val wrapper = wrapper.get() ?: return
+            val title = title.get() ?: return
+            val ancCard = ancCard.get() ?: return
+            val accessory = accessory.get() ?: return
+            wrapper.visibility = ancCard.visibility
+            accessory.visibility =
+                if (ancCard.isVisible && title.isVisible) View.VISIBLE else View.GONE
+            controller.render(state, accessory)
+        }
+
+        override fun unbind() {
+            val parent = parent.get() ?: return
+            val wrapper = wrapper.get() ?: return
+            val title = title.get() ?: return
+            controller.unbind()
+            if (wrapper.parent !== parent) return
+            (title.parent as? ViewGroup)?.removeView(title)
+            parent.removeView(wrapper)
+            originalLayoutParams.width = originalWidth
+            title.layoutParams = originalLayoutParams
+            parent.addView(title, originalIndex.coerceAtMost(parent.childCount))
+        }
+    }
+
+    private class EmbeddedBinding(
+        parent: ViewGroup,
+        private val originalIndex: Int,
+        private val originalLayoutParams: ViewGroup.LayoutParams,
+        private val originalBackground: Drawable?,
+        wrapper: ViewGroup,
+        ancCard: LinearLayout,
+        accessory: View,
+        private val controller: FitBudsTurboController,
+    ) : MiLinkCardBinding {
+        private val parent = WeakReference(parent)
+        private val wrapper = WeakReference(wrapper)
+        private val ancCard = WeakReference(ancCard)
+        private val accessory = WeakReference(accessory)
+
+        override fun render(state: EarbudState) {
+            val wrapper = wrapper.get() ?: return
+            val ancCard = ancCard.get() ?: return
+            val accessory = accessory.get() ?: return
+            wrapper.visibility = ancCard.visibility
+            accessory.visibility = if (ancCard.isVisible) View.VISIBLE else View.GONE
+            controller.render(state, accessory)
+        }
+
+        override fun unbind() {
+            controller.unbind()
+            val parent = parent.get() ?: return
+            val wrapper = wrapper.get() ?: return
+            val ancCard = ancCard.get() ?: return
+            if (wrapper.parent !== parent) return
+            (ancCard.parent as? ViewGroup)?.removeView(ancCard)
+            parent.removeView(wrapper)
+            ancCard.background = originalBackground
+            ancCard.layoutParams = originalLayoutParams
+            parent.addView(ancCard, originalIndex.coerceAtMost(parent.childCount))
+        }
+    }
+
+    /**
+     * Owns the two accessory switches. The wind toggle reuses the ANC-branch policy; the game
+     * toggle maps onto the Edifier low-latency request. Both are rendered from [EarbudState] and
+     * only ever issue a request — the authoritative state is restored from the protocol pipeline.
+     */
+    private class FitBudsTurboController(
+        windToggle: CompoundButton,
+        gameToggle: CompoundButton,
+        private val address: String,
+        private val environment: MiLinkCardEnvironment,
+    ) {
+        private val windToggle = WeakReference(windToggle)
+        private val gameToggle = WeakReference(gameToggle)
+        private var rendering = false
+
+        fun bind() {
+            windToggle.get()?.setOnCheckedChangeListener(::onWindChanged)
+            gameToggle.get()?.setOnCheckedChangeListener(::onGameChanged)
+        }
+
+        fun render(state: EarbudState, accessory: View) {
+            val windToggle = windToggle.get() ?: return
+            val gameToggle = gameToggle.get() ?: return
+            val wind = WindNoiseToggleControlPolicy.render(state)
+            val game = FitBudsTurboGameModePolicy.render(state)
+            rendering = true
+            try {
+                windToggle.isChecked = wind.checked
+                windToggle.isEnabled = wind.enabled
+                gameToggle.isChecked = game.checked
+                gameToggle.isEnabled = game.enabled
+                val anyEnabled = wind.enabled || game.enabled
+                val alpha = if (anyEnabled) ENABLED_ALPHA else DISABLED_ALPHA
+                windToggle.alpha = if (wind.enabled) ENABLED_ALPHA else DISABLED_ALPHA
+                gameToggle.alpha = if (game.enabled) ENABLED_ALPHA else DISABLED_ALPHA
+                accessory.alpha = alpha
+            } finally {
+                rendering = false
+            }
+        }
+
+        fun unbind() {
+            windToggle.get()?.setOnCheckedChangeListener(null)
+            gameToggle.get()?.setOnCheckedChangeListener(null)
+        }
+
+        private fun onWindChanged(button: CompoundButton, checked: Boolean) {
+            if (rendering) return
+            val current = environment.stateProvider(address)
+            val currentWind = WindNoiseToggleControlPolicy.render(current)
+            rendering = true
+            try {
+                button.isChecked = currentWind.checked
+            } finally {
+                rendering = false
+            }
+            val requestedMode = WindNoiseToggleControlPolicy.request(current, checked) ?: return
+            environment.controlSender(
+                address,
+                StandardControlRequest.SetNoiseMode(requestedMode),
+            )
+        }
+
+        private fun onGameChanged(button: CompoundButton, checked: Boolean) {
+            if (rendering) return
+            val current = environment.stateProvider(address)
+            val currentGame = FitBudsTurboGameModePolicy.render(current)
+            rendering = true
+            try {
+                button.isChecked = currentGame.checked
+            } finally {
+                rendering = false
+            }
+            val requested = FitBudsTurboGameModePolicy.request(current, checked) ?: return
+            environment.controlSender(
+                address,
+                EdifierControlRequest.SetGameMode(requested),
+            )
+        }
+    }
+
+    private fun createHostToggle(
+        context: Context,
+        hostClassLoader: ClassLoader,
+    ): CompoundButton = runCatching {
+        Class.forName(MIUIX_SLIDING_BUTTON, true, hostClassLoader)
+            .asSubclass(CompoundButton::class.java)
+            .getConstructor(Context::class.java)
+            .newInstance(context)
+    }.getOrElse {
+        @Suppress("DEPRECATION")
+        Switch(context)
+    }
+
+    private fun Context.dp(value: Int): Int =
+        (value * resources.displayMetrics.density).toInt()
+
+    private fun resolveTitleAncCard(root: View): TitleAncCard? =
+        resolveSelectAncCard(root) ?: resolveOriginalTitleAncCard(root)
+
+    private fun resolveOriginalTitleAncCard(root: View): TitleAncCard? {
+        val originalTitle = root.findMiLinkView(ORIGINAL_ANC_CARD_TITLE_ID) as? TextView
+        val originalCard = root.findMiLinkView(ORIGINAL_ANC_CARD_ID)
+        if (originalTitle == null || originalCard == null) return null
+        return TitleAncCard(
+            generation = NativeAncCardGeneration.ORIGINAL,
+            title = originalTitle,
+            container = originalCard,
+        )
+    }
+
+    private fun resolveSelectAncCard(root: View): TitleAncCard? {
+        val selectTitle = root.findMiLinkView(SELECT_ANC_CARD_TITLE_ID) as? TextView ?: return null
+        val selectCard = root.findMiLinkView(SELECT_ANC_CARD_ID) as? LinearLayout ?: return null
+        if (selectCard.javaClass.name != SELECT_ANC_CARD_CLASS) return null
+        if (selectCard.childCount != NATIVE_MODE_COUNT) return null
+        if ((0 until selectCard.childCount).any { index ->
+                selectCard.getChildAt(index).javaClass.name != SELECT_ANC_ITEM_CLASS
+            }
+        ) {
+            return null
+        }
+        return TitleAncCard(
+            generation = NativeAncCardGeneration.SELECT_CARD,
+            title = selectTitle,
+            container = selectCard,
+        )
+    }
+
+    private fun resolveEmbeddedAncCard(root: View): EmbeddedAncCard? {
+        val card = root.findMiLinkView(ORIGINAL_ANC_CARD_ID) as? LinearLayout ?: return null
+        val transparency = root.findMiLinkView(ORIGINAL_ANC_TRANSPARENCY_ID) ?: return null
+        val noiseCancellation =
+            root.findMiLinkView(ORIGINAL_ANC_NOISE_CANCELLATION_ID) ?: return null
+        val off = root.findMiLinkView(ORIGINAL_ANC_OFF_ID) ?: return null
+        val nativeItems = listOf(transparency, noiseCancellation, off)
+        if (nativeItems.any { item ->
+                item.parent !== card || item.javaClass.name != ORIGINAL_ANC_ITEM_CLASS
+            }
+        ) {
+            return null
+        }
+        val styleSource = noiseCancellation.findMiLinkView(ORIGINAL_ANC_ITEM_TITLE_ID)
+            as? TextView
+            ?: return null
+        return EmbeddedAncCard(
+            container = card,
+            styleSource = styleSource,
+        )
+    }
+
+    private data class TitleAncCard(
+        val generation: NativeAncCardGeneration,
+        val title: TextView,
+        val container: View,
+    )
+
+    private data class EmbeddedAncCard(
+        val container: LinearLayout,
+        val styleSource: TextView,
+    )
+
+    private enum class NativeAncCardGeneration(val logName: String) {
+        ORIGINAL("original"),
+        SELECT_CARD("select-card"),
+    }
+}
+
+private const val COMPONENT = "MiLinkUi"
+private const val ORIGINAL_ANC_CARD_TITLE_ID = "anc_card_title"
+private const val ORIGINAL_ANC_CARD_ID = "anc_card"
+private const val ORIGINAL_ANC_TRANSPARENCY_ID = "anc_clear"
+private const val ORIGINAL_ANC_NOISE_CANCELLATION_ID = "anc_noise_cancel"
+private const val ORIGINAL_ANC_OFF_ID = "anc_off"
+private const val ORIGINAL_ANC_ITEM_TITLE_ID = "anc_title"
+private const val ORIGINAL_ANC_ITEM_CLASS =
+    "com.miui.circulate.world.headset.ui.HeadsetControlAncItemView"
+private const val SELECT_ANC_CARD_TITLE_ID = "anc_card_text"
+private const val SELECT_ANC_CARD_ID = "anc_select_card"
+private const val SELECT_ANC_CARD_CLASS =
+    "com.miui.circulate.world.headset.ui.HeadsetSelectCardView"
+private const val SELECT_ANC_ITEM_CLASS =
+    "com.miui.circulate.world.headset.ui.HeadsetSelectItemView"
+private const val NATIVE_MODE_COUNT = 3
+private const val MIUIX_SLIDING_BUTTON = "miuix.slidingwidget.widget.SlidingButton"
+private const val WIND_LABEL = "抗风噪"
+private const val GAME_MODE_LABEL = "游戏模式"
+private const val LABEL_END_PADDING_DP = 8
+private const val GAME_LABEL_START_PADDING_DP = 16
+private const val EMBEDDED_HEADER_HEIGHT_DP = 48
+private const val EMBEDDED_HEADER_HORIZONTAL_PADDING_DP = 20
+private const val ENABLED_ALPHA = 1.0f
+private const val DISABLED_ALPHA = 0.45f
+
+/**
+ * Pure game-mode toggle policy for the FitBuds Turbo card; UI code contains no independent state.
+ *
+ * The switch is enabled only while the session is active and connected and the game-mode feature
+ * has been observed (i.e. the 0x08 query answered). Requesting a state that is already current
+ * returns null so no redundant command is sent.
+ */
+internal object FitBudsTurboGameModePolicy {
+    data class ToggleState(
+        val checked: Boolean,
+        val enabled: Boolean,
+    )
+
+    fun render(state: EarbudState): ToggleState {
+        val feature = state.features.get<EdifierGameModeFeatureState>()
+        return ToggleState(
+            checked = feature?.enabled == true,
+            enabled = state.sessionActive && state.connected && feature != null,
+        )
+    }
+
+    fun request(state: EarbudState, checked: Boolean): Boolean? {
+        val current = render(state)
+        if (!current.enabled || current.checked == checked) return null
+        return checked
+    }
+}

--- a/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
+++ b/system-module/src/main/java/dev/hyperears/hook/MiLinkCardAdapter.kt
@@ -78,6 +78,7 @@ internal object MiLinkCardAdapterRegistry {
         BoseAnrMiLinkCardAdapter,
         BoseTwoModeMiLinkCardAdapter,
         EdifierFourModeMiLinkCardAdapter,
+        EdifierFitBudsTurboMiLinkCardAdapter,
         FitClipUltraGameModeMiLinkCardAdapter,
         SonyAmbientOnlyMiLinkCardAdapter,
     )

--- a/system-module/src/test/java/dev/hyperears/hook/MiLinkCardAdapterRegistryTest.kt
+++ b/system-module/src/test/java/dev/hyperears/hook/MiLinkCardAdapterRegistryTest.kt
@@ -2,17 +2,26 @@ package dev.hyperears.hook
 
 import dev.hyperears.integration.BoseQuietComfortHeadphonesAdapter
 import dev.hyperears.integration.BoseMiLinkPresentationIds
+import dev.hyperears.integration.DeviceLifecycle
+import dev.hyperears.integration.EarbudState
+import dev.hyperears.integration.EdifierGameModeFeatureState
 import dev.hyperears.integration.EdifierMiLinkPresentationIds
 import dev.hyperears.integration.MiLinkCardPresentationId
 import dev.hyperears.integration.NiceHckYuanDaoOrigAdapter
 import dev.hyperears.integration.NoiseMode
+import dev.hyperears.integration.PrivateTransportState
+import dev.hyperears.integration.ProtocolHandshakeState
 import dev.hyperears.integration.RoseBudsFeelMk2Adapter
 import dev.hyperears.integration.RoseEarfreeI5Adapter
 import dev.hyperears.integration.StarRingUltraAdapter
+import dev.hyperears.integration.SystemProfileState
 import dev.hyperears.integration.SonyMiLinkPresentationIds
+import dev.hyperears.integration.withFeature
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MiLinkCardAdapterRegistryTest {
@@ -65,6 +74,10 @@ class MiLinkCardAdapterRegistryTest {
             ),
         )
         assertSame(
+            EdifierFitBudsTurboMiLinkCardAdapter,
+            MiLinkCardAdapterRegistry.resolve(EdifierMiLinkPresentationIds.FITBUDS_TURBO),
+        )
+        assertSame(
             FitClipUltraGameModeMiLinkCardAdapter,
             MiLinkCardAdapterRegistry.resolve(EdifierMiLinkPresentationIds.GAME_MODE),
         )
@@ -77,5 +90,42 @@ class MiLinkCardAdapterRegistryTest {
                 MiLinkCardPresentationId("unknown-model"),
             ),
         )
+    }
+
+    @Test
+    fun fitBudsTurboGameModeDisabledUntilFeatureObserved() {
+        val idle = EarbudState(
+            lifecycle = DeviceLifecycle(
+                SystemProfileState.CONNECTED,
+                PrivateTransportState.NOT_REQUIRED,
+                ProtocolHandshakeState.NOT_REQUIRED,
+            ),
+        )
+        val idleToggle = FitBudsTurboGameModePolicy.render(idle)
+        assertFalse("game switch must be disabled without the feature", idleToggle.enabled)
+    }
+
+    @Test
+    fun fitBudsTurboGameModeTracksFeatureAndRequestsToggle() {
+        val active = EarbudState(
+            lifecycle = DeviceLifecycle(
+                SystemProfileState.CONNECTED,
+                PrivateTransportState.NOT_REQUIRED,
+                ProtocolHandshakeState.NOT_REQUIRED,
+            ),
+        )
+        val gameOff = active.withFeature(EdifierGameModeFeatureState(enabled = false))
+        val offToggle = FitBudsTurboGameModePolicy.render(gameOff)
+        assertTrue(offToggle.enabled)
+        assertFalse(offToggle.checked)
+        // Requesting game mode on while it is off should yield true (send a command).
+        assertEquals(true, FitBudsTurboGameModePolicy.request(gameOff, checked = true))
+        // Requesting the current state must be a no-op.
+        assertNull(FitBudsTurboGameModePolicy.request(gameOff, checked = false))
+
+        val gameOn = active.withFeature(EdifierGameModeFeatureState(enabled = true))
+        assertTrue(FitBudsTurboGameModePolicy.render(gameOn).checked)
+        assertEquals(false, FitBudsTurboGameModePolicy.request(gameOn, checked = false))
+        assertNull(FitBudsTurboGameModePolicy.request(gameOn, checked = true))
     }
 }


### PR DESCRIPTION
## Summary

Add full HyperOS MiLink integration for the **EDIFIER FitBuds Turbo**, verified working on-device (2026-09-01).

## What this adds

- **New adapter** `EdifierFitBudsTurboAdapter`: exact device-name match, per-ear battery via the `0xF2` device-state query, EVO_PRO ANC dialect probing, and a game-mode feature.
- **Protocol support**: `EdifierWireCodec` gains `plaintext` payload handling (FitBuds Turbo answers BES queries without the XOR 0xA5 obfuscation) and game-mode state query/set (`0x08`/`0x09`).
- **New MiLink card adapter** `EdifierFitBudsTurboMiLinkCardAdapter`: attaches both a **wind-noise toggle** and a **game-mode switch** to the native ANC card, alongside the ANC three-state (transparency / ANC / off).
- Registration in `EarbudAdapter` and `MiLinkCardAdapterRegistry`, plus unit tests for registry resolution and the game-mode policy.

## Files changed (8)

- `integration/.../EarbudAdapter.kt` — register the new adapter
- `integration/.../EdifierEarbudAdapter.kt` — plaintext payload + game-mode wiring
- `integration/.../EdifierFitBudsTurboAdapter.kt` — **new**
- `protocol/.../edifier/EdifierWireCodec.kt` — plaintext + game-mode support
- `protocol/.../edifier/EdifierWireCodecTest.kt` — tests
- `system-module/.../EdifierFitBudsTurboMiLinkCardAdapter.kt` — **new** card
- `system-module/.../MiLinkCardAdapter.kt` — register the card
- `system-module/.../MiLinkCardAdapterRegistryTest.kt` — tests

## Verified

Per-ear battery, ANC four-mode (transparency/ANC/wind/off), wind-noise toggle and game-mode switch all work in the HyperOS device center on a rooted + LSPosed + HyperOS device.

## Notes

- Debug-signed APK built via the `build-patch-apk` workflow for validation (kept out of this PR).
- Requires root + LSPosed.